### PR TITLE
Implement PartialEq + Eq for RNGs

### DIFF
--- a/rand_isaac/CHANGELOG.md
+++ b/rand_isaac/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Derive PartialEq+Eq for IsaacRng, IsaacCore, Isaac64Rng, Isaac64Core, and IsaacArray (#6)
+
 ## [0.2.0] - 2019-06-12
 - Bump minor crate version since rand_core bump is a breaking change
 - Switch to Edition 2018

--- a/rand_isaac/CHANGELOG.md
+++ b/rand_isaac/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Derive PartialEq+Eq for IsaacRng, IsaacCore, Isaac64Rng, Isaac64Core, and IsaacArray (#6)
+- Derive PartialEq+Eq for IsaacCore, Isaac64Core, and IsaacArray (#6)
 
 ## [0.2.0] - 2019-06-12
 - Bump minor crate version since rand_core bump is a breaking change

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -23,9 +23,9 @@ serde1 = ["serde", "rand_core/serde1"]
 
 [dependencies]
 rand_core = { version = "0.5" }
-serde = { version = "1.0.63", features = ["derive"], optional = true }
+serde = { version = "1.0.103", features = ["derive"], optional = true }
 # Not a direct dependency but required to boost the minimum version:
-serde_derive = { version = "1.0.63", optional = true }
+serde_derive = { version = "1.0.103", optional = true }
 
 [dev-dependencies]
 # This is for testing serde, unfortunately we can't specify feature-gated dev

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_isaac"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -22,7 +22,7 @@ appveyor = { repository = "rust-random/rngs" }
 serde1 = ["serde", "rand_core/serde1"]
 
 [dependencies]
-rand_core = { version = "0.5" }
+rand_core = { version = "0.5.2" }
 serde = { version = "1.0.63", features = ["derive"], optional = true }
 # Not a direct dependency but required to boost the minimum version:
 serde_derive = { version = "1.0.63", optional = true }

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -22,7 +22,7 @@ appveyor = { repository = "rust-random/rngs" }
 serde1 = ["serde", "rand_core/serde1"]
 
 [dependencies]
-rand_core = { version = "0.5.2" }
+rand_core = { version = "0.5" }
 serde = { version = "1.0.63", features = ["derive"], optional = true }
 # Not a direct dependency but required to boost the minimum version:
 serde_derive = { version = "1.0.63", optional = true }

--- a/rand_isaac/src/isaac.rs
+++ b/rand_isaac/src/isaac.rs
@@ -88,7 +88,7 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 ///       https://eprint.iacr.org/2006/438)
 ///
 /// [`rand_hc`]: https://docs.rs/rand_hc
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct IsaacRng(BlockRng<IsaacCore>);
 

--- a/rand_isaac/src/isaac.rs
+++ b/rand_isaac/src/isaac.rs
@@ -88,7 +88,7 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 ///       https://eprint.iacr.org/2006/438)
 ///
 /// [`rand_hc`]: https://docs.rs/rand_hc
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct IsaacRng(BlockRng<IsaacCore>);
 
@@ -152,6 +152,20 @@ impl fmt::Debug for IsaacCore {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "IsaacCore {{}}")
     }
+}
+
+// Custom PartialEq implementation as it can't currently be derived from an array of size RAND_SIZE
+impl ::core::cmp::PartialEq for IsaacCore {
+    fn eq(&self, other: &IsaacCore) -> bool {
+        &self.mem[..] == &other.mem[..]
+            && self.a == other.a
+            && self.b == other.b
+            && self.c == other.c
+    }
+}
+
+// Custom Eq implementation as it can't currently be derived from an array of size RAND_SIZE
+impl ::core::cmp::Eq for IsaacCore {
 }
 
 impl BlockRngCore for IsaacCore {

--- a/rand_isaac/src/isaac64.rs
+++ b/rand_isaac/src/isaac64.rs
@@ -79,7 +79,7 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 /// [`IsaacRng`]: crate::isaac::IsaacRng
 /// [`rand_hc`]: https://docs.rs/rand_hc
 /// [`BlockRng64`]: rand_core::block::BlockRng64
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Isaac64Rng(BlockRng64<Isaac64Core>);
 

--- a/rand_isaac/src/isaac64.rs
+++ b/rand_isaac/src/isaac64.rs
@@ -79,7 +79,7 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 /// [`IsaacRng`]: crate::isaac::IsaacRng
 /// [`rand_hc`]: https://docs.rs/rand_hc
 /// [`BlockRng64`]: rand_core::block::BlockRng64
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Isaac64Rng(BlockRng64<Isaac64Core>);
 
@@ -143,6 +143,20 @@ impl fmt::Debug for Isaac64Core {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Isaac64Core {{}}")
     }
+}
+
+// Custom PartialEq implementation as it can't currently be derived from an array of size RAND_SIZE
+impl ::core::cmp::PartialEq for Isaac64Core {
+    fn eq(&self, other: &Isaac64Core) -> bool {
+        &self.mem[..] == &other.mem[..]
+            && self.a == other.a
+            && self.b == other.b
+            && self.c == other.c
+    }
+}
+
+// Custom Eq implementation as it can't currently be derived from an array of size RAND_SIZE
+impl ::core::cmp::Eq for Isaac64Core {
 }
 
 impl BlockRngCore for Isaac64Core {

--- a/rand_isaac/src/isaac_array.rs
+++ b/rand_isaac/src/isaac_array.rs
@@ -65,6 +65,17 @@ impl<T> ::core::default::Default for IsaacArray<T> where T: Copy + Default {
     }
 }
 
+// Custom PartialEq implementation as it can't currently be derived from an array of size RAND_SIZE
+impl<T> ::core::cmp::PartialEq for IsaacArray<T> where T: PartialEq {
+    fn eq(&self, other: &IsaacArray<T>) -> bool {
+        &self.inner[..] == &other.inner[..]
+    }
+}
+
+// Custom Eq implementation as it can't currently be derived from an array of size RAND_SIZE
+impl<T> ::core::cmp::Eq for IsaacArray<T> where T: Eq {
+}
+
 
 #[cfg(feature="serde")]
 pub(super) mod isaac_array_serde {

--- a/rand_xorshift/CHANGELOG.md
+++ b/rand_xorshift/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Derive PartialEq+Eq for XorShiftRng (#6)
+
 ## [0.2.0] - 2019-06-12
 - Bump minor crate version since rand_core bump is a breaking change
 - Switch to Edition 2018

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_xorshift"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_xorshift/src/lib.rs
+++ b/rand_xorshift/src/lib.rs
@@ -31,7 +31,7 @@ use rand_core::{RngCore, SeedableRng, Error, impls, le};
 /// [^1]: Marsaglia, George (July 2003).
 ///       ["Xorshift RNGs"](https://www.jstatsoft.org/v08/i14/paper).
 ///       *Journal of Statistical Software*. Vol. 8 (Issue 14).
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize,Deserialize))]
 pub struct XorShiftRng {
     x: w<u32>,

--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Derive PartialEq+Eq for SplitMix64, Xoroshiro64Star, Xoroshiro64StarStar,
+  Xoroshiro128Plus, Xoroshiro128PlusPlus, Xoroshiro128StarStar,
+  Xoshiro128Plus, Xoshiro128PlusPlus, Xoshiro128StarStar, Xoshiro256Plus,
+  Xoshiro256PlusPlus, Xoshiro256StarStar, Xoshiro512Plus, Xoshiro512PlusPlus,
+  and Xoshiro512StarStar (#6)
+
 ## [0.4.0] - 2019-09-03
 - Add xoshiro128++, 256++ and 512++ variants
 - Add xoroshiro128++ variant

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_xoshiro"
-version = "0.4.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.4.1" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_xoshiro/src/lib.rs
+++ b/rand_xoshiro/src/lib.rs
@@ -70,7 +70,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_xoshiro/0.4.0")]
+       html_root_url = "https://docs.rs/rand_xoshiro/0.4.1")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/rand_xoshiro/src/splitmix64.rs
+++ b/rand_xoshiro/src/splitmix64.rs
@@ -21,7 +21,7 @@ use rand_core::{RngCore, SeedableRng, Error};
 /// Sebastiano Vigna. For `next_u32`, a more efficient mixing function taken
 /// from [`dsiutils`](http://dsiutils.di.unimi.it/) is used.
 #[allow(missing_copy_implementations)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct SplitMix64 {
     x: u64,

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -22,7 +22,7 @@ use rand_core::{RngCore, SeedableRng};
 /// reference source code](http://xoshiro.di.unimi.it/xoroshiro128plus.c) by
 /// David Blackman and Sebastiano Vigna.
 #[allow(missing_copy_implementations)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoroshiro128Plus {
     s0: u64,

--- a/rand_xoshiro/src/xoroshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoroshiro128plusplus.rs
@@ -21,7 +21,7 @@ use rand_core::{RngCore, SeedableRng};
 /// reference source code](http://xoshiro.di.unimi.it/xoroshiro128plusplus.c) by
 /// David Blackman and Sebastiano Vigna.
 #[allow(missing_copy_implementations)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoroshiro128PlusPlus {
     s0: u64,

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -21,7 +21,7 @@ use rand_core::{RngCore, SeedableRng};
 /// reference source code](http://xoshiro.di.unimi.it/xoroshiro128starstar.c) by
 /// David Blackman and Sebastiano Vigna.
 #[allow(missing_copy_implementations)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoroshiro128StarStar {
     s0: u64,

--- a/rand_xoshiro/src/xoroshiro64star.rs
+++ b/rand_xoshiro/src/xoroshiro64star.rs
@@ -22,7 +22,7 @@ use rand_core::{RngCore, SeedableRng};
 /// reference source code](http://xoshiro.di.unimi.it/xoroshiro64star.c) by
 /// David Blackman and Sebastiano Vigna.
 #[allow(missing_copy_implementations)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoroshiro64Star {
     s0: u32,

--- a/rand_xoshiro/src/xoroshiro64starstar.rs
+++ b/rand_xoshiro/src/xoroshiro64starstar.rs
@@ -21,7 +21,7 @@ use rand_core::{RngCore, SeedableRng};
 /// reference source code](http://xoshiro.di.unimi.it/xoroshiro64starstar.c) by
 /// David Blackman and Sebastiano Vigna.
 #[allow(missing_copy_implementations)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoroshiro64StarStar {
     s0: u32,

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -20,7 +20,7 @@ use rand_core::{SeedableRng, RngCore, Error};
 /// The algorithm used here is translated from [the `xoshiro128starstar.c`
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro128starstar.c) by
 /// David Blackman and Sebastiano Vigna.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoshiro128Plus {
     s: [u32; 4],

--- a/rand_xoshiro/src/xoshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoshiro128plusplus.rs
@@ -19,7 +19,7 @@ use rand_core::{SeedableRng, RngCore, Error};
 /// The algorithm used here is translated from [the `xoshiro128plusplus.c`
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro128plusplus.c) by
 /// David Blackman and Sebastiano Vigna.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoshiro128PlusPlus {
     s: [u32; 4],

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -19,7 +19,7 @@ use rand_core::{SeedableRng, RngCore, Error};
 /// The algorithm used here is translated from [the `xoshiro128starstar.c`
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro128starstar.c) by
 /// David Blackman and Sebastiano Vigna.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoshiro128StarStar {
     s: [u32; 4],

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -20,7 +20,7 @@ use rand_core::{SeedableRng, RngCore, Error};
 /// The algorithm used here is translated from [the `xoshiro256plus.c`
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro256plus.c) by
 /// David Blackman and Sebastiano Vigna.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoshiro256Plus {
     s: [u64; 4],

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -19,7 +19,7 @@ use rand_core::{SeedableRng, RngCore, Error};
 /// The algorithm used here is translated from [the `xoshiro256plusplus.c`
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro256plusplus.c) by
 /// David Blackman and Sebastiano Vigna.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoshiro256PlusPlus {
     s: [u64; 4],

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -19,7 +19,7 @@ use rand_core::{SeedableRng, RngCore, Error};
 /// The algorithm used here is translated from [the `xoshiro256starstar.c`
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro256starstar.c) by
 /// David Blackman and Sebastiano Vigna.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoshiro256StarStar {
     s: [u64; 4],

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -22,7 +22,7 @@ use crate::Seed512;
 /// The algorithm used here is translated from [the `xoshiro512plus.c`
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro512plus.c) by
 /// David Blackman and Sebastiano Vigna.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoshiro512Plus {
     s: [u64; 8],

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -21,7 +21,7 @@ use crate::Seed512;
 /// The algorithm used here is translated from [the `xoshiro512plusplus.c`
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro512plusplus.c) by
 /// David Blackman and Sebastiano Vigna.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoshiro512PlusPlus {
     s: [u64; 8],

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -21,7 +21,7 @@ use crate::Seed512;
 /// The algorithm used here is translated from [the `xoshiro512starstar.c`
 /// reference source code](http://xoshiro.di.unimi.it/xoshiro512starstar.c) by
 /// David Blackman and Sebastiano Vigna.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct Xoshiro512StarStar {
     s: [u64; 8],


### PR DESCRIPTION
This rebases #6 and reverts the changes to `IsaacRng` and `Isaac64Rng` for now, because they require `BlockRng` to implement those traits first.