### PR TITLE
Prefer upper bits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ members = [
 [dev-dependencies]
 # Only for benches:
 rand_core = { version = "0.5", features = ["getrandom"] }
-rand_xoshiro = { path = "rand_xoshiro", version = "0.4" }
+rand_xoshiro = { path = "rand_xoshiro", version = "0.5" }
 rand_isaac = { path = "rand_isaac", version = "0.2" }
 rand_xorshift = { path = "rand_xorshift", version = "0.2" }

--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2020-09-11
 - Derive PartialEq+Eq for SplitMix64, Xoroshiro64Star, Xoroshiro64StarStar,
   Xoroshiro128Plus, Xoroshiro128PlusPlus, Xoroshiro128StarStar,
   Xoshiro128Plus, Xoshiro128PlusPlus, Xoshiro128StarStar, Xoshiro256Plus,
   Xoshiro256PlusPlus, Xoshiro256StarStar, Xoshiro512Plus, Xoshiro512PlusPlus,
   and Xoshiro512StarStar (#6)
+- `next_u32`: Prefer upper bits for `Xoshiro256{PlusPlus,StarStar}` and
+  `Xoshiro512{Plus,PlusPlus,StarStar}`, breaking value stability
 
 ## [0.4.0] - 2019-09-03
 - Add xoshiro128++, 256++ and 512++ variants

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_xoshiro"
-version = "0.4.1" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.5.0" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_xoshiro/src/lib.rs
+++ b/rand_xoshiro/src/lib.rs
@@ -70,7 +70,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_xoshiro/0.4.1")]
+       html_root_url = "https://docs.rs/rand_xoshiro/0.5.0")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -83,7 +83,9 @@ impl SeedableRng for Xoshiro256PlusPlus {
 impl RngCore for Xoshiro256PlusPlus {
     #[inline]
     fn next_u32(&mut self) -> u32 {
-        self.next_u64() as u32
+        // The lowest bits have some linear dependencies, so we use the
+        // upper bits instead.
+        (self.next_u64() >> 32) as u32
     }
 
     #[inline]

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -83,7 +83,9 @@ impl SeedableRng for Xoshiro256StarStar {
 impl RngCore for Xoshiro256StarStar {
     #[inline]
     fn next_u32(&mut self) -> u32 {
-        self.next_u64() as u32
+        // The lowest bits have some linear dependencies, so we use the
+        // upper bits instead.
+        (self.next_u64() >> 32) as u32
     }
 
     #[inline]

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -88,7 +88,9 @@ impl SeedableRng for Xoshiro512Plus {
 impl RngCore for Xoshiro512Plus {
     #[inline]
     fn next_u32(&mut self) -> u32 {
-        self.next_u64() as u32
+        // The lowest bits have some linear dependencies, so we use the
+        // upper bits instead.
+        (self.next_u64() >> 32) as u32
     }
 
     #[inline]

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -88,7 +88,9 @@ impl SeedableRng for Xoshiro512PlusPlus {
 impl RngCore for Xoshiro512PlusPlus {
     #[inline]
     fn next_u32(&mut self) -> u32 {
-        self.next_u64() as u32
+        // The lowest bits have some linear dependencies, so we use the
+        // upper bits instead.
+        (self.next_u64() >> 32) as u32
     }
 
     #[inline]

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -88,7 +88,9 @@ impl SeedableRng for Xoshiro512StarStar {
 impl RngCore for Xoshiro512StarStar {
     #[inline]
     fn next_u32(&mut self) -> u32 {
-        self.next_u64() as u32
+        // The lowest bits have some linear dependencies, so we use the
+        // upper bits instead.
+        (self.next_u64() >> 32) as u32
     }
 
     #[inline]


### PR DESCRIPTION
This is a value-breaking change to `next_u32` affecting `Xoshiro256{PlusPlus,StarStar}` and `Xoshiro512{Plus,PlusPlus,StarStar}`.