### PR TITLE
rand_xorshift: Depend on no-std serde

### DIFF
--- a/rand_xorshift/CHANGELOG.md
+++ b/rand_xorshift/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Derive PartialEq+Eq for XorShiftRng (#6)
+- Bump serde to 1.0.118 so that `serde1` feature can also be no-std (#12)
 
 ## [0.2.0] - 2019-06-12
 - Bump minor crate version since rand_core bump is a breaking change

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -23,7 +23,7 @@ serde1 = ["serde"]
 
 [dependencies]
 rand_core = { version = "0.5" }
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1.0.118", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 # This is for testing serde, unfortunately we can't specify feature-gated dev


### PR DESCRIPTION
Prior to this, enabling rand_xorshift's `serde1` feature also pulled in `std` because `core::num::Wrapping` wasn't `serde::Serialize`. As of serde 1.0.118, it is, so we can now depend on no-std serde.