### PR TITLE
fix Miri flag passing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,4 +129,4 @@ jobs:
           cargo miri test --manifest-path rand_isaac/Cargo.toml --all-features
           cargo miri test --manifest-path rand_xorshift/Cargo.toml --all-features
           cargo miri test --manifest-path rand_xoshiro/Cargo.toml --all-features
-          cargo miri test --manifest-path rand_jitter/Cargo.toml -- -Zmiri-disable-isolation
+          MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --manifest-path rand_jitter/Cargo.toml


### PR DESCRIPTION
With https://github.com/rust-lang/miri/pull/1769 having landed, the old way of passing flags to Miri will soon stop working. This updates the CI to the new way.