### PR TITLE
Add comment explaining shift amounts for xorshift

### DIFF
--- a/rand_xorshift/src/lib.rs
+++ b/rand_xorshift/src/lib.rs
@@ -55,6 +55,8 @@ impl fmt::Debug for XorShiftRng {
 impl RngCore for XorShiftRng {
     #[inline]
     fn next_u32(&mut self) -> u32 {
+        // These shifts are taken from the example in the Summary section of
+        // the paper 'Xorshift RNGs'. (On the bottom of page 5.)
         let x = self.x;
         let t = x ^ (x << 11);
         self.x = self.y;


### PR DESCRIPTION
This is a very tiny PR, but when reviewing the code I was wondering where the constants in Xorshift came from. I added a comment explaining that.