### PR TITLE
Fix a typo in crate documentation

### DIFF
--- a/rand_xoshiro/src/lib.rs
+++ b/rand_xoshiro/src/lib.rs
@@ -8,7 +8,7 @@
 
 //! This crate implements the [xoshiro] family of pseudorandom number generators
 //! designed by David Blackman and Sebastiano Vigna. They feature high
-//! perfomance and a small state and superseed the previous xorshift-based
+//! perfomance and a small state and supersede the previous xorshift-based
 //! generators. However, they are not cryptographically secure and their output
 //! can be predicted by observing a few samples.
 //!


### PR DESCRIPTION
superseed → supersede