### PR TITLE
reduce stack allocation in `Hc128Core::init` for embedded use

### DIFF
--- a/rand_hc/CHANGELOG.md
+++ b/rand_hc/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2023-04-15
+- Reduce stack use in `Hc128Core::init`
+
 ## [0.3.1] - 2021-06-15
 - Adjust crate links
 

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_hc"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_hc/src/hc128.rs
+++ b/rand_hc/src/hc128.rs
@@ -299,7 +299,8 @@ impl Hc128Core {
             x.rotate_right(17) ^ x.rotate_right(19) ^ (x >> 10)
         }
 
-        let mut t = [0u32; 1024];
+        let mut core = Self { t: [0u32; 1024], counter1024: 0 };
+        let t = &mut core.t;
 
         // Expand the key and iv into P and Q
         let (key, iv) = seed.split_at(4);
@@ -330,8 +331,6 @@ impl Hc128Core {
                 .wrapping_add(t[i - 16])
                 .wrapping_add(256 + i as u32);
         }
-
-        let mut core = Self { t, counter1024: 0 };
 
         // run the cipher 1024 steps
         for _ in 0..64 {


### PR DESCRIPTION
hi folks, in the process of getting HC-128 working on an _very constrained_ embedded platform i noticed a double allocation in `Hc128Core::init`... 

this PR alters the init function to create the object early then reference the internal array, reducing the stack use for this function by 4kB (~40%) and letting the optimiser do it's copy-elision thing ^_^