### PR TITLE
Update to rand master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ exclude = [
     "benches",
 ]
 resolver = "2"
+
+[patch.crates-io.rand_core]
+git = "https://github.com/rust-random/rand.git"
+branch = "master"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dev-dependencies]
 criterion = "0.5.0"
 criterion-cycles-per-byte = "0.6"
-rand_core = { version = "0.6.4", features = ["getrandom"] }
+rand_core = { version = "=0.9.0-alpha.1", features = ["getrandom"] }
 rand_xoshiro = { path = "../rand_xoshiro", version = "0.6" }
 rand_isaac = { path = "../rand_isaac", version = "0.3" }
 rand_xorshift = { path = "../rand_xorshift", version = "0.3" }

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -16,4 +16,4 @@ edition = "2021"
 rust-version = "1.61"
 
 [dependencies]
-rand_core = "0.6"
+rand_core = "=0.9.0-alpha.1"

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.61"
 serde1 = ["serde", "rand_core/serde1"]
 
 [dependencies]
-rand_core = { version = "0.6" }
+rand_core = { version = "=0.9.0-alpha.1" }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 # Not a direct dependency but required to boost the minimum version:
 serde_derive = { version = "1.0.103", optional = true }

--- a/rand_isaac/src/isaac64.rs
+++ b/rand_isaac/src/isaac64.rs
@@ -13,7 +13,7 @@ use crate::isaac_array::IsaacArray;
 use core::num::Wrapping as w;
 use core::{fmt, slice};
 use rand_core::block::{BlockRng64, BlockRngCore};
-use rand_core::{le, Error, RngCore, SeedableRng};
+use rand_core::{le, RngCore, SeedableRng, TryRngCore};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -99,12 +99,9 @@ impl RngCore for Isaac64Rng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest)
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.0.try_fill_bytes(dest)
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Isaac64Rng);
 
 impl SeedableRng for Isaac64Rng {
     type Seed = <Isaac64Core as SeedableRng>::Seed;
@@ -123,8 +120,13 @@ impl SeedableRng for Isaac64Rng {
     }
 
     #[inline]
-    fn from_rng<S: RngCore>(rng: S) -> Result<Self, Error> {
-        BlockRng64::<Isaac64Core>::from_rng(rng).map(Isaac64Rng)
+    fn from_rng(rng: impl RngCore) -> Self {
+        Isaac64Rng(BlockRng64::<Isaac64Core>::from_rng(rng))
+    }
+
+    #[inline]
+    fn try_from_rng<S: TryRngCore>(rng: S) -> Result<Self, S::Error> {
+        BlockRng64::<Isaac64Core>::try_from_rng(rng).map(Isaac64Rng)
     }
 }
 
@@ -327,7 +329,23 @@ impl SeedableRng for Isaac64Core {
         Self::init(key, 1)
     }
 
-    fn from_rng<R: RngCore>(mut rng: R) -> Result<Self, Error> {
+    fn from_rng(mut rng: impl RngCore) -> Self {
+        // Custom `from_rng` implementation that fills a seed with the same size
+        // as the entire state.
+        let mut seed = [w(0u64); RAND_SIZE];
+        unsafe {
+            let ptr = seed.as_mut_ptr() as *mut u8;
+            let slice = slice::from_raw_parts_mut(ptr, RAND_SIZE * 8);
+            rng.fill_bytes(slice);
+        }
+        for i in seed.iter_mut() {
+            *i = w(i.0.to_le());
+        }
+
+        Self::init(seed, 2)
+    }
+
+    fn try_from_rng<R: TryRngCore>(mut rng: R) -> Result<Self, R::Error> {
         // Custom `from_rng` implementation that fills a seed with the same size
         // as the entire state.
         let mut seed = [w(0u64); RAND_SIZE];
@@ -359,7 +377,7 @@ mod test {
         let mut rng1 = Isaac64Rng::from_seed(seed);
         assert_eq!(rng1.next_u64(), 14964555543728284049);
 
-        let mut rng2 = Isaac64Rng::from_rng(rng1).unwrap();
+        let mut rng2 = Isaac64Rng::from_rng(rng1);
         assert_eq!(rng2.next_u64(), 919595328260451758);
     }
 

--- a/rand_jitter/Cargo.toml
+++ b/rand_jitter/Cargo.toml
@@ -16,7 +16,7 @@ std = ["rand_core/std"]
 log = ["dep:log"]
 
 [dependencies]
-rand_core = { version = "0.6" }
+rand_core = { version = "=0.9.0-alpha.1" }
 log = { version = "0.4.4", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/rand_jitter/src/error.rs
+++ b/rand_jitter/src/error.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 use core::fmt;
-use rand_core::Error;
 
 /// Base code for all `JitterRng` errors
 const ERROR_BASE: u32 = 0xAE53_0400;
@@ -61,20 +60,5 @@ impl fmt::Display for TimerError {
 impl ::std::error::Error for TimerError {
     fn description(&self) -> &str {
         self.description()
-    }
-}
-
-impl From<TimerError> for Error {
-    fn from(err: TimerError) -> Error {
-        // Timer check is already quite permissive of failures so we don't
-        // expect false-positive failures, i.e. any error is irrecoverable.
-        #[cfg(feature = "std")]
-        {
-            Error::new(err)
-        }
-        #[cfg(not(feature = "std"))]
-        {
-            Error::from(core::num::NonZeroU32::new(err as u32).unwrap())
-        }
     }
 }

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.61"
 serde1 = ["serde"]
 
 [dependencies]
-rand_core = { version = "0.6" }
+rand_core = { version = "=0.9.0-alpha.1" }
 serde = { version = "1.0.118", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/rand_xorshift/tests/mod.rs
+++ b/rand_xorshift/tests/mod.rs
@@ -8,7 +8,7 @@ fn test_xorshift_construction() {
     let mut rng1 = XorShiftRng::from_seed(seed);
     assert_eq!(rng1.next_u64(), 4325440999699518727);
 
-    let mut rng2 = XorShiftRng::from_rng(&mut rng1).unwrap();
+    let mut rng2 = XorShiftRng::from_rng(&mut rng1);
     // Yes, this makes rng2 a clone of rng1!
     assert_eq!(rng1.next_u64(), 15614385950550801700);
     assert_eq!(rng2.next_u64(), 15614385950550801700);

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.61"
 serde1 = ["serde"]
 
 [dependencies]
-rand_core = { version = "0.6" }
+rand_core = { version = "=0.9.0-alpha.1" }
 serde = { version = "1", features = ["derive"], optional=true }
 
 [dev-dependencies]

--- a/rand_xoshiro/src/common.rs
+++ b/rand_xoshiro/src/common.rs
@@ -10,7 +10,7 @@
 macro_rules! from_splitmix {
     ($seed:expr) => {{
         let mut rng = crate::SplitMix64::seed_from_u64($seed);
-        Self::from_rng(&mut rng).unwrap()
+        Self::from_rng(&mut rng)
     }};
 }
 

--- a/rand_xoshiro/src/splitmix64.rs
+++ b/rand_xoshiro/src/splitmix64.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::fill_bytes_via_next;
 use rand_core::le::read_u64_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -57,13 +57,9 @@ impl RngCore for SplitMix64 {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(SplitMix64);
 
 impl SeedableRng for SplitMix64 {
     type Seed = [u8; 8];

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -78,13 +78,9 @@ impl RngCore for Xoroshiro128Plus {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoroshiro128Plus);
 
 impl SeedableRng for Xoroshiro128Plus {
     type Seed = [u8; 16];

--- a/rand_xoshiro/src/xoroshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoroshiro128plusplus.rs
@@ -75,13 +75,9 @@ impl RngCore for Xoroshiro128PlusPlus {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoroshiro128PlusPlus);
 
 impl SeedableRng for Xoroshiro128PlusPlus {
     type Seed = [u8; 16];

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -75,13 +75,9 @@ impl RngCore for Xoroshiro128StarStar {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoroshiro128StarStar);
 
 impl SeedableRng for Xoroshiro128StarStar {
     type Seed = [u8; 16];

--- a/rand_xoshiro/src/xoroshiro64star.rs
+++ b/rand_xoshiro/src/xoroshiro64star.rs
@@ -46,13 +46,9 @@ impl RngCore for Xoroshiro64Star {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoroshiro64Star);
 
 impl SeedableRng for Xoroshiro64Star {
     type Seed = [u8; 8];

--- a/rand_xoshiro/src/xoroshiro64starstar.rs
+++ b/rand_xoshiro/src/xoroshiro64starstar.rs
@@ -45,13 +45,9 @@ impl RngCore for Xoroshiro64StarStar {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoroshiro64StarStar);
 
 impl SeedableRng for Xoroshiro64StarStar {
     type Seed = [u8; 8];

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::{fill_bytes_via_next, next_u64_via_u32};
 use rand_core::le::read_u32_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -93,14 +93,8 @@ impl RngCore for Xoshiro128Plus {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
-
+rand_core::impl_try_rng_from_rng_core!(Xoshiro128Plus);
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rand_xoshiro/src/xoshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoshiro128plusplus.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::{fill_bytes_via_next, next_u64_via_u32};
 use rand_core::le::read_u32_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -92,13 +92,9 @@ impl RngCore for Xoshiro128PlusPlus {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoshiro128PlusPlus);
 
 #[cfg(test)]
 mod tests {

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::{fill_bytes_via_next, next_u64_via_u32};
 use rand_core::le::read_u32_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -92,13 +92,9 @@ impl RngCore for Xoshiro128StarStar {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoshiro128StarStar);
 
 #[cfg(test)]
 mod tests {

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::fill_bytes_via_next;
 use rand_core::le::read_u64_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -113,13 +113,9 @@ impl RngCore for Xoshiro256Plus {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoshiro256Plus);
 
 #[cfg(test)]
 mod tests {

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::fill_bytes_via_next;
 use rand_core::le::read_u64_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -112,13 +112,9 @@ impl RngCore for Xoshiro256PlusPlus {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoshiro256PlusPlus);
 
 #[cfg(test)]
 mod tests {

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::fill_bytes_via_next;
 use rand_core::le::read_u64_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -112,13 +112,9 @@ impl RngCore for Xoshiro256StarStar {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoshiro256StarStar);
 
 #[cfg(test)]
 mod tests {

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::fill_bytes_via_next;
 use rand_core::le::read_u64_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -123,13 +123,9 @@ impl RngCore for Xoshiro512Plus {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoshiro512Plus);
 
 #[cfg(test)]
 mod tests {

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::fill_bytes_via_next;
 use rand_core::le::read_u64_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -122,13 +122,9 @@ impl RngCore for Xoshiro512PlusPlus {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoshiro512PlusPlus);
 
 #[cfg(test)]
 mod tests {

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -8,7 +8,7 @@
 
 use rand_core::impls::fill_bytes_via_next;
 use rand_core::le::read_u64_into;
-use rand_core::{Error, RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -122,13 +122,9 @@ impl RngCore for Xoshiro512StarStar {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+rand_core::impl_try_rng_from_rng_core!(Xoshiro512StarStar);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Temporarily, we patch this repo to use rand from git. Not ideal, but:

- It lets us get this code (mostly) ready for the next rand version now
- Lets us test the rand_core changes
- Allows us to move rand_pcg here, if we want to (possibly not; it is used by benches in the rand repo)