### PR TITLE
Updates for rand_jitter

### DIFF
--- a/rand_jitter/Cargo.toml
+++ b/rand_jitter/Cargo.toml
@@ -18,6 +18,7 @@ log = ["dep:log"]
 [dependencies]
 rand_core = { version = "=0.9.0-alpha.1" }
 log = { version = "0.4.4", optional = true }
+sha3 = { version = "0.10.8" }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 # We don't need the 'use_std' feature and depending on it causes

--- a/rand_jitter/src/hw_timers.rs
+++ b/rand_jitter/src/hw_timers.rs
@@ -1,0 +1,26 @@
+/// returns a 64 Bit timestamp with an optimized implementation
+/// on x86 platforms, based on the rdtsc instruction
+///
+/// May use it instead of get_nstime, if your platform supports it.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub fn get_nstime_rdtsc() -> u64 {
+    use core::arch::asm;
+
+    let eax: u32;
+    let edx: u32;
+
+    // rdtsc should be preferred against rdtscp, as it
+    // typically introduces a higher amount of clock jitter
+    // due to missing dependencies on previous instructions
+    // and loads becoming visible
+    unsafe {
+        asm!(
+          "rdtsc",
+          lateout("eax") eax,
+          lateout("edx") edx,
+          options(nomem, nostack)
+        )
+    }
+
+    u64::from(edx) << 32 | u64::from(eax)
+}

--- a/rand_jitter/src/lib.rs
+++ b/rand_jitter/src/lib.rs
@@ -57,6 +57,12 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+/// This module contains optimized hardware timers.
+/// They can be used instead of the generic get_nstime
+/// or on bare hardware without the std feature.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub mod hw_timers;
+
 pub use rand_core;
 
 // Coming from https://crates.io/crates/doc-comment


### PR DESCRIPTION
I started updating rand_jitter towards the ideas of the current SHA-3 based implementation of [jitterentropy](https://www.chronox.de/jent/).

Currently this is early work in a very rough draft. Before I continue, is there any interest in this update?