### PR TITLE
Implementations of SFC32/SFC64 chaotic RNGs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "rand_xorshift",
     "rand_xoshiro",
     "rand_hc",
+    "rand_sfc"
 ]
 exclude = [
     "benches",

--- a/rand_sfc/Cargo.toml
+++ b/rand_sfc/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rand_sfc"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.63"
+keywords = ["random", "rng", "sfc"]
+categories = ["algorithms", "no-std"]
+
+[features]
+serde1 = ["serde"]
+
+[dependencies]
+rand_core = { version = "0.9.0" }
+serde = { version = "1.0.118", default-features = false, features = ["derive"], optional = true }

--- a/rand_sfc/src/lib.rs
+++ b/rand_sfc/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright 2025 XXX.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This crate implements the sfc (Small Fast Counting) family of pseudorandom
+//! number generators designed by Chris Doty-Humphrey, author of the [PractRand]
+//! pseudorandom number generator testing suite. The generators have a small
+//! state, good statistical quality, and high performance. Like most generators
+//! intended for non-cryptographic use, they can be [predicted]. They also have
+//! a variable period, but the counter present in the state provides a fixed
+//! lower bound and [most states] are on the longest cycle.
+//!
+//! This crate provides:
+//! - [`Sfc64`]: 64 bit output, seed space 192 bits, worst-case period 2^64,
+//! and expected period ~2^255.
+//! - [`Sfc32`]: 32 bit output, seed space 96 bits, worst-case period 2^32,
+//! and expected period ~2^127.
+//!
+//! The implementations provided are derived from PractRand.
+//!
+//! [PractRand]: https://pracrand.sourceforge.net/
+//! [predicted]: https://github.com/michaelni/randomtests/blob/main/sfc64-breach.c
+//! [most states]: https://www.pcg-random.org/posts/random-invertible-mapping-statistics.html
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
+#![no_std]
+
+mod sfc32;
+mod sfc64;
+
+pub use rand_core;
+pub use sfc32::Sfc32;
+pub use sfc64::Sfc64;

--- a/rand_sfc/src/sfc32.rs
+++ b/rand_sfc/src/sfc32.rs
@@ -1,0 +1,130 @@
+// Copyright 2025 XXX.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rand_core::le::read_u32_into;
+use rand_core::{RngCore, SeedableRng};
+use rand_core::impls::{fill_bytes_via_next, next_u64_via_u32};
+
+#[allow(missing_copy_implementations)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
+/// An sfc32 random number generator.
+///
+/// Good performance and statistical quality, but not cryptographically secure
+/// and has a large difference between its worst-case and maximum period.
+///
+/// This implementation is derived ultimately from
+/// [`the PractRand RNG test suite`](https://pracrand.sourceforge.net/) by
+/// Chris Doty-Humphrey.
+pub struct Sfc32 {
+    a: u32,
+    b: u32,
+    c: u32,
+    weyl: u32,
+}
+
+const BARREL_SHIFT: u32 = 21;
+const RSHIFT: u32 = 9;
+const LSHIFT: u32 = 3;
+// WEYL_INC is always 1 in the PractRand implementation, but some other
+// implementations use it to provide a stream facility. This is not yet
+// implemented here, though.
+const WEYL_INC: u32 = 1;
+
+impl RngCore for Sfc32 {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        let old_b = self.b;
+        let old_c = self.c;
+        let old_weyl = self.weyl;
+
+        let result = self.a.wrapping_add(old_b).wrapping_add(old_weyl);
+        self.a = old_b ^ (old_b >> RSHIFT);
+        self.b = old_c.wrapping_add(old_c << LSHIFT);
+        self.c = result.wrapping_add(old_c.rotate_left(BARREL_SHIFT));
+        self.weyl = old_weyl.wrapping_add(WEYL_INC);
+        result
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        next_u64_via_u32(self)
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        fill_bytes_via_next(self, dest);
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+// PracRand uses different mixing step counts for different types of seeds.
+// Here, just use one of the larger values always.
+const SEED_MIXING_STEPS: u32 = 16;
+
+impl SeedableRng for Sfc32 {
+    type Seed = [u8; 12];
+
+    /// Create a new `Sfc32`.
+    fn from_seed(seed: [u8; 12]) -> Sfc32 {
+        let mut s = [0; 3];
+        read_u32_into(&seed, &mut s);
+
+        let mut gen = Sfc32 {
+            a: s[0],
+            b: s[1],
+            c: s[2],
+            weyl: WEYL_INC
+        };
+
+        for _ in 0..SEED_MIXING_STEPS {
+            gen.next_u32();
+        }
+
+        gen
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference() {
+        // These values were produced with the reference implementation:
+        // https://pracrand.sourceforge.net/
+        let mut gen = Sfc32::from_seed([0, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0]);
+        let expected: [u32; 16] = [
+            0xA87DBC7E,
+            0x1787178C,
+            0x4C7B7234,
+            0xC65DADE2,
+            0x2C692349,
+            0xF52C2153,
+            0xDF098072,
+            0x9D49B03C,
+            0x9562381A,
+            0xC9B41738,
+            0x64B75E54,
+            0x36CE9B32,
+            0xF106947E,
+            0x0AFC726B,
+            0x549BBC87,
+            0xD19A7B3E
+        ];
+
+        for &e in &expected {
+            assert_eq!(gen.next_u32(), e);
+        }
+    }
+}

--- a/rand_sfc/src/sfc32.rs
+++ b/rand_sfc/src/sfc32.rs
@@ -60,12 +60,6 @@ impl RngCore for Sfc32 {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
 
 // PracRand uses different mixing step counts for different types of seeds.

--- a/rand_sfc/src/sfc64.rs
+++ b/rand_sfc/src/sfc64.rs
@@ -63,12 +63,6 @@ impl RngCore for Sfc64 {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
 
 // PracRand uses different mixing step counts for different types of seeds.

--- a/rand_sfc/src/sfc64.rs
+++ b/rand_sfc/src/sfc64.rs
@@ -1,0 +1,137 @@
+// Copyright 2025 XXX.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rand_core::le::read_u64_into;
+use rand_core::{RngCore, SeedableRng};
+use rand_core::impls::fill_bytes_via_next;
+
+#[allow(missing_copy_implementations)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
+/// An sfc64 random number generator.
+///
+/// Good performance and statistical quality, but not cryptographically secure
+/// and has a large difference between its worst-case and maximum period.
+/// sfc64 has a longer period than sfc32 and should perform as well or better
+/// on 64-bit processors, though Chris Doty-Humphrey believes its statistical
+/// properties are similar to sfc32.
+///
+/// This implementation is derived ultimately from
+/// [`the PractRand RNG test suite`](https://pracrand.sourceforge.net/) by
+/// Chris Doty-Humphrey.
+pub struct Sfc64 {
+    a: u64,
+    b: u64,
+    c: u64,
+    weyl: u64,
+}
+
+const BARREL_SHIFT: u32 = 24;
+const RSHIFT: u32 = 11;
+const LSHIFT: u32 = 3;
+// WEYL_INC is always 1 in the PractRand implementation, but some other
+// implementations use it to provide a stream facility. This is not yet
+// implemented here, though.
+const WEYL_INC: u64 = 1;
+
+impl RngCore for Sfc64 {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        (self.next_u64() >> 32) as u32
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        let old_b = self.b;
+        let old_c = self.c;
+        let old_weyl = self.weyl;
+
+        let result = self.a.wrapping_add(old_b).wrapping_add(old_weyl);
+        self.a = old_b ^ (old_b >> RSHIFT);
+        self.b = old_c.wrapping_add(old_c << LSHIFT);
+        self.c = result.wrapping_add(old_c.rotate_left(BARREL_SHIFT));
+        self.weyl = self.weyl.wrapping_add(WEYL_INC);
+        result
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        fill_bytes_via_next(self, dest);
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+// PracRand uses different mixing step counts for different types of seeds.
+// Here, just use one of the larger values always.
+const SEED_MIXING_STEPS: u32 = 18;
+
+impl SeedableRng for Sfc64 {
+    type Seed = [u8; 24];
+
+    /// Create a new `Sfc64`.
+    fn from_seed(seed: [u8; 24]) -> Sfc64 {
+        let mut s = [0; 3];
+        read_u64_into(&seed, &mut s);
+
+        let mut gen = Sfc64 {
+            a: s[0],
+            b: s[1],
+            c: s[2],
+            weyl: WEYL_INC
+        };
+
+        for _ in 0..SEED_MIXING_STEPS {
+            gen.next_u64();
+        }
+        gen
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference() {
+        // These values were produced with the reference implementation:
+        // https://pracrand.sourceforge.net/
+        let mut gen = Sfc64::from_seed([
+            1, 0, 0, 0, 0, 0, 0, 0,
+            1, 0, 0, 0, 0, 0, 0, 0,
+            1, 0, 0, 0, 0, 0, 0, 0,
+        ]);
+
+        let expected: [u64; 16] = [
+            0xAD6FDC729FEEF3C1,
+            0x2A20433D733F77D5,
+            0x0310E21369647420,
+            0x331A176BC71DCABC,
+            0x53118F35C2494D94,
+            0xA3A99DE7E77E16BF,
+            0xA7B1B70A3E59A1FF,
+            0x8E1127B28667EB3C,
+            0x3FC589DC124CF6E8,
+            0x81E0EAAACEB81D81,
+            0x79F534652D262DF6,
+            0x87F70C8214E186C5,
+            0x67AF9C007B825917,
+            0x5134AEC9998D8629,
+            0x205AA24994068634,
+            0x1C762918DBA3E139
+        ];
+
+        for &e in &expected {
+            assert_eq!(gen.next_u64(), e);
+        }
+    }
+}


### PR DESCRIPTION
This adds an implementation of the SFC32 and SFC64 chaotic RNGs.

There's some work left to be done regarding docs and formatting but they should work.