### PR TITLE
Use postcard for serde tests

### DIFF
--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -29,4 +29,4 @@ serde_arrays = { version = "0.2.0", optional = true }
 [dev-dependencies]
 # This is for testing serde, unfortunately we can't specify feature-gated dev
 # deps yet, see: https://github.com/rust-lang/cargo/issues/1596
-bincode = "1.1.4"
+postcard = {version = "1.1.3", default-features = false, features = ["alloc"] }

--- a/rand_isaac/src/isaac.rs
+++ b/rand_isaac/src/isaac.rs
@@ -664,9 +664,6 @@ mod test {
     #[test]
     #[cfg(feature = "serde")]
     fn test_isaac_serde() {
-        use bincode;
-        use std::io::{BufReader, BufWriter};
-
         let seed = [
             1, 0, 0, 0, 23, 0, 0, 0, 200, 1, 0, 0, 210, 30, 0, 0, 57, 48, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0,
@@ -677,14 +674,9 @@ mod test {
         let _ = rng.next_u64();
         let _ = rng.next_u32();
 
-        let buf: Vec<u8> = Vec::new();
-        let mut buf = BufWriter::new(buf);
-        bincode::serialize_into(&mut buf, &rng).expect("Could not serialize");
+        let buf = postcard::to_allocvec(&rng).expect("Could not serialize");
 
-        let buf = buf.into_inner().unwrap();
-        let mut read = BufReader::new(&buf[..]);
-        let mut deserialized: IsaacRng =
-            bincode::deserialize_from(&mut read).expect("Could not deserialize");
+        let mut deserialized: IsaacRng = postcard::from_bytes(&buf).expect("Could not deserialize");
 
         // more than the 256 buffered results
         for _ in 0..300 {

--- a/rand_isaac/src/isaac64.rs
+++ b/rand_isaac/src/isaac64.rs
@@ -669,9 +669,6 @@ mod test {
     #[test]
     #[cfg(feature = "serde")]
     fn test_isaac64_serde() {
-        use bincode;
-        use std::io::{BufReader, BufWriter};
-
         let seed = [
             1, 0, 0, 0, 23, 0, 0, 0, 200, 1, 0, 0, 210, 30, 0, 0, 57, 48, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0,
@@ -682,14 +679,10 @@ mod test {
         let _ = rng.next_u64();
         let _ = rng.next_u32();
 
-        let buf: Vec<u8> = Vec::new();
-        let mut buf = BufWriter::new(buf);
-        bincode::serialize_into(&mut buf, &rng).expect("Could not serialize");
+        let buf = postcard::to_allocvec(&rng).expect("Could not serialize");
 
-        let buf = buf.into_inner().unwrap();
-        let mut read = BufReader::new(&buf[..]);
         let mut deserialized: Isaac64Rng =
-            bincode::deserialize_from(&mut read).expect("Could not deserialize");
+            postcard::from_bytes(&buf).expect("Could not deserialize");
 
         // more than the 256 buffered results
         for _ in 0..300 {

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -28,4 +28,4 @@ serde = { version = "1.0.118", default-features = false, features = ["derive"], 
 [dev-dependencies]
 # This is for testing serde, unfortunately we can't specify feature-gated dev
 # deps yet, see: https://github.com/rust-lang/cargo/issues/1596
-bincode = "1"
+postcard = {version = "1.1.3", default-features = false, features = ["alloc"] }

--- a/rand_xorshift/tests/mod.rs
+++ b/rand_xorshift/tests/mod.rs
@@ -80,20 +80,12 @@ fn test_xorshift_clone() {
 #[cfg(feature = "serde")]
 #[test]
 fn test_xorshift_serde() {
-    use bincode;
-    use std::io::{BufReader, BufWriter};
-
     let seed = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
     let mut rng = XorShiftRng::from_seed(seed);
 
-    let buf: Vec<u8> = Vec::new();
-    let mut buf = BufWriter::new(buf);
-    bincode::serialize_into(&mut buf, &rng).expect("Could not serialize");
+    let buf = postcard::to_allocvec(&rng).expect("Could not serialize");
 
-    let buf = buf.into_inner().unwrap();
-    let mut read = BufReader::new(&buf[..]);
-    let mut deserialized: XorShiftRng =
-        bincode::deserialize_from(&mut read).expect("Could not deserialize");
+    let mut deserialized: XorShiftRng = postcard::from_bytes(&buf).expect("Could not deserialize");
 
     for _ in 0..16 {
         assert_eq!(rng.next_u64(), deserialized.next_u64());

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -26,4 +26,4 @@ serde = { version = "1", features = ["derive"], optional=true }
 [dev-dependencies]
 # This is for testing serde, unfortunately we can't specify feature-gated dev
 # deps yet, see: https://github.com/rust-lang/cargo/issues/1596
-bincode = { version = "1" }
+postcard = {version = "1.1.3", default-features = false, features = ["alloc"] }

--- a/rand_xoshiro/tests/serde.rs
+++ b/rand_xoshiro/tests/serde.rs
@@ -9,19 +9,11 @@ use rand_xoshiro::{
 
 macro_rules! serde_rng {
     ($rng:ident) => {
-        use bincode;
-        use std::io::{BufReader, BufWriter};
-
         let mut rng = $rng::seed_from_u64(0);
 
-        let buf: Vec<u8> = Vec::new();
-        let mut buf = BufWriter::new(buf);
-        bincode::serialize_into(&mut buf, &rng).expect("Could not serialize");
+        let buf = postcard::to_allocvec(&rng).expect("Could not serialize");
 
-        let buf = buf.into_inner().unwrap();
-        let mut read = BufReader::new(&buf[..]);
-        let mut deserialized: $rng =
-            bincode::deserialize_from(&mut read).expect("Could not deserialize");
+        let mut deserialized: $rng = postcard::from_bytes(&buf).expect("Could not deserialize");
 
         for _ in 0..16 {
             assert_eq!(rng.next_u64(), deserialized.next_u64());


### PR DESCRIPTION
Replaces usage of bincode.