### PR TITLE
rand_xoshiro: Add `state()` for serde-free state export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "postcard",
  "rand_core",

--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.1] - 2026-05-15
 ### Added
 - `state()` method on every RNG type returning the internal state as a value
   matching `SeedableRng::Seed`, allowing reproduction via `from_seed` without

--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -5,9 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `state()` method on every RNG type returning the internal state as a value
+  matching `SeedableRng::Seed`, allowing reproduction via `from_seed` without
+  the `serde` feature ([#110]).
+
 ### Changed
 - Shrink the code size of the all-zero-seed fallback by replacing the per-RNG
   `SplitMix64::seed_from_u64(0)` call with a single shared constant.
+
+[#110]: https://github.com/rust-random/rngs/pull/110
 
 ## [0.8.0] - 2026-02-01
 ### Changes

--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.1] - 2026-05-15
+## [0.8.1] - 2026-05-16
 ### Added
 - `state()` method on every RNG type returning the internal state as a value
   matching `SeedableRng::Seed`, allowing reproduction via `from_seed` without

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_xoshiro"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_xoshiro/src/common.rs
+++ b/rand_xoshiro/src/common.rs
@@ -222,26 +222,9 @@ macro_rules! impl_xoshiro_large {
     };
 }
 
-/// Implement `state`, returning the internal state of a single-word RNG as
-/// little-endian bytes that round-trip through [`SeedableRng::from_seed`].
-macro_rules! impl_state_scalar {
-    ($type:ident) => {
-        impl $type {
-            /// Return the internal state of the generator as little-endian
-            /// bytes that can be passed to [`SeedableRng::from_seed`] to
-            /// reconstruct an identical generator.
-            ///
-            /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
-            pub fn state(&self) -> [u8; 8] {
-                self.x.to_le_bytes()
-            }
-        }
-    };
-}
-
 /// Implement `state` for an RNG with two word-sized fields `s0` and `s1`.
 macro_rules! impl_state_pair {
-    ($type:ident, $word:ty, $bytes:literal) => {
+    ($type:ident, $word:ty) => {
         impl $type {
             /// Return the internal state of the generator as little-endian
             /// bytes that can be passed to [`SeedableRng::from_seed`] to
@@ -253,20 +236,21 @@ macro_rules! impl_state_pair {
             /// remapped to `seed_from_u64(0)`.)
             ///
             /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
-            pub fn state(&self) -> [u8; $bytes] {
-                let mut out = [0u8; $bytes];
-                let n = core::mem::size_of::<$word>();
-                out[..n].copy_from_slice(&self.s0.to_le_bytes());
-                out[n..].copy_from_slice(&self.s1.to_le_bytes());
+            pub fn state(&self) -> [u8; 2 * core::mem::size_of::<$word>()] {
+                const N: usize = core::mem::size_of::<$word>();
+                const { assert!(core::mem::size_of::<Self>() == 2 * N); }
+                let mut out = [0u8; 2 * N];
+                out[..N].copy_from_slice(&self.s0.to_le_bytes());
+                out[N..].copy_from_slice(&self.s1.to_le_bytes());
                 out
             }
         }
     };
 }
 
-/// Implement `state` for an RNG with a `s: [WORD; N]` field.
-macro_rules! impl_state_array {
-    ($type:ident, $word:ty, $bytes:literal) => {
+/// Implement `state` for an RNG with an `s: [WORD; 4]` field.
+macro_rules! impl_state_array_of_four {
+    ($type:ident, $word:ty) => {
         impl $type {
             /// Return the internal state of the generator as little-endian
             /// bytes that can be passed to [`SeedableRng::from_seed`] to
@@ -278,12 +262,14 @@ macro_rules! impl_state_array {
             /// remapped to `seed_from_u64(0)`.)
             ///
             /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
-            pub fn state(&self) -> [u8; $bytes] {
-                let mut out = [0u8; $bytes];
-                let n = core::mem::size_of::<$word>();
-                for (i, word) in self.s.iter().enumerate() {
-                    out[i * n..(i + 1) * n].copy_from_slice(&word.to_le_bytes());
-                }
+            pub fn state(&self) -> [u8; 4 * core::mem::size_of::<$word>()] {
+                const N: usize = core::mem::size_of::<$word>();
+                const { assert!(core::mem::size_of::<Self>() == 4 * N); }
+                let mut out = [0u8; 4 * N];
+                out[..N].copy_from_slice(&self.s[0].to_le_bytes());
+                out[N..2 * N].copy_from_slice(&self.s[1].to_le_bytes());
+                out[2 * N..3 * N].copy_from_slice(&self.s[2].to_le_bytes());
+                out[3 * N..].copy_from_slice(&self.s[3].to_le_bytes());
                 out
             }
         }

--- a/rand_xoshiro/src/common.rs
+++ b/rand_xoshiro/src/common.rs
@@ -238,7 +238,9 @@ macro_rules! impl_state_pair {
             /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
             pub fn state(&self) -> [u8; 2 * core::mem::size_of::<$word>()] {
                 const N: usize = core::mem::size_of::<$word>();
-                const { assert!(core::mem::size_of::<Self>() == 2 * N); }
+                const {
+                    assert!(core::mem::size_of::<Self>() == 2 * N);
+                }
                 let mut out = [0u8; 2 * N];
                 out[..N].copy_from_slice(&self.s0.to_le_bytes());
                 out[N..].copy_from_slice(&self.s1.to_le_bytes());
@@ -264,7 +266,9 @@ macro_rules! impl_state_array_of_four {
             /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
             pub fn state(&self) -> [u8; 4 * core::mem::size_of::<$word>()] {
                 const N: usize = core::mem::size_of::<$word>();
-                const { assert!(core::mem::size_of::<Self>() == 4 * N); }
+                const {
+                    assert!(core::mem::size_of::<Self>() == 4 * N);
+                }
                 let mut out = [0u8; 4 * N];
                 out[..N].copy_from_slice(&self.s[0].to_le_bytes());
                 out[N..2 * N].copy_from_slice(&self.s[1].to_le_bytes());

--- a/rand_xoshiro/src/common.rs
+++ b/rand_xoshiro/src/common.rs
@@ -222,6 +222,99 @@ macro_rules! impl_xoshiro_large {
     };
 }
 
+/// Implement `state`, returning the internal state of a single-word RNG as
+/// little-endian bytes that round-trip through [`SeedableRng::from_seed`].
+macro_rules! impl_state_scalar {
+    ($type:ident) => {
+        impl $type {
+            /// Return the internal state of the generator as little-endian
+            /// bytes that can be passed to [`SeedableRng::from_seed`] to
+            /// reconstruct an identical generator.
+            ///
+            /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
+            pub fn state(&self) -> [u8; 8] {
+                self.x.to_le_bytes()
+            }
+        }
+    };
+}
+
+/// Implement `state` for an RNG with two word-sized fields `s0` and `s1`.
+macro_rules! impl_state_pair {
+    ($type:ident, $word:ty, $bytes:literal) => {
+        impl $type {
+            /// Return the internal state of the generator as little-endian
+            /// bytes that can be passed to [`SeedableRng::from_seed`] to
+            /// reconstruct an identical generator.
+            ///
+            /// The all-zero state is unreachable from any non-zero seed, so
+            /// the round-trip is exact for any generator obtained via the
+            /// usual constructors. (An all-zero input to `from_seed` is
+            /// remapped to `seed_from_u64(0)`.)
+            ///
+            /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
+            pub fn state(&self) -> [u8; $bytes] {
+                let mut out = [0u8; $bytes];
+                let n = core::mem::size_of::<$word>();
+                out[..n].copy_from_slice(&self.s0.to_le_bytes());
+                out[n..].copy_from_slice(&self.s1.to_le_bytes());
+                out
+            }
+        }
+    };
+}
+
+/// Implement `state` for an RNG with a `s: [WORD; N]` field.
+macro_rules! impl_state_array {
+    ($type:ident, $word:ty, $bytes:literal) => {
+        impl $type {
+            /// Return the internal state of the generator as little-endian
+            /// bytes that can be passed to [`SeedableRng::from_seed`] to
+            /// reconstruct an identical generator.
+            ///
+            /// The all-zero state is unreachable from any non-zero seed, so
+            /// the round-trip is exact for any generator obtained via the
+            /// usual constructors. (An all-zero input to `from_seed` is
+            /// remapped to `seed_from_u64(0)`.)
+            ///
+            /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
+            pub fn state(&self) -> [u8; $bytes] {
+                let mut out = [0u8; $bytes];
+                let n = core::mem::size_of::<$word>();
+                for (i, word) in self.s.iter().enumerate() {
+                    out[i * n..(i + 1) * n].copy_from_slice(&word.to_le_bytes());
+                }
+                out
+            }
+        }
+    };
+}
+
+/// Implement `state` for a 512-bit RNG (`s: [u64; 8]`), returning a [`Seed512`].
+macro_rules! impl_state_seed512 {
+    ($type:ident) => {
+        impl $type {
+            /// Return the internal state of the generator as a [`Seed512`]
+            /// that can be passed to [`SeedableRng::from_seed`] to reconstruct
+            /// an identical generator.
+            ///
+            /// The all-zero state is unreachable from any non-zero seed, so
+            /// the round-trip is exact for any generator obtained via the
+            /// usual constructors. (An all-zero input to `from_seed` is
+            /// remapped to `seed_from_u64(0)`.)
+            ///
+            /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
+            pub fn state(&self) -> crate::Seed512 {
+                let mut out = [0u8; 64];
+                for (i, word) in self.s.iter().enumerate() {
+                    out[i * 8..(i + 1) * 8].copy_from_slice(&word.to_le_bytes());
+                }
+                crate::Seed512(out)
+            }
+        }
+    };
+}
+
 /// Fallback seed used when `from_seed` is called with an all-zero input.
 ///
 /// Equal to the first 64 bytes of `SplitMix64::seed_from_u64(0)`'s output.

--- a/rand_xoshiro/src/splitmix64.rs
+++ b/rand_xoshiro/src/splitmix64.rs
@@ -60,6 +60,8 @@ impl TryRng for SplitMix64 {
     }
 }
 
+impl_state_scalar!(SplitMix64);
+
 impl SeedableRng for SplitMix64 {
     type Seed = [u8; 8];
 
@@ -139,6 +141,18 @@ mod tests {
         ];
         for &e in expected.iter() {
             assert_eq!(rng.next_u64(), e);
+        }
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = SplitMix64::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = SplitMix64::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
         }
     }
 

--- a/rand_xoshiro/src/splitmix64.rs
+++ b/rand_xoshiro/src/splitmix64.rs
@@ -60,7 +60,16 @@ impl TryRng for SplitMix64 {
     }
 }
 
-impl_state_scalar!(SplitMix64);
+impl SplitMix64 {
+    /// Return the internal state of the generator as little-endian bytes
+    /// that can be passed to [`SeedableRng::from_seed`] to reconstruct an
+    /// identical generator.
+    ///
+    /// [`SeedableRng::from_seed`]: rand_core::SeedableRng::from_seed
+    pub fn state(&self) -> [u8; 8] {
+        self.x.to_le_bytes()
+    }
+}
 
 impl SeedableRng for SplitMix64 {
     type Seed = [u8; 8];
@@ -146,14 +155,9 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = SplitMix64::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = SplitMix64::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = SplitMix64::seed_from_u64(42);
+        let clone = SplitMix64::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 
     #[test]

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -80,6 +80,8 @@ impl TryRng for Xoroshiro128Plus {
         utils::fill_bytes_via_next_word(dest, || self.try_next_u64())
     }
 }
+impl_state_pair!(Xoroshiro128Plus, u64, 16);
+
 impl SeedableRng for Xoroshiro128Plus {
     type Seed = [u8; 16];
 
@@ -128,5 +130,17 @@ mod tests {
         let from_zero = Xoroshiro128Plus::from_seed([0u8; 16]);
         let from_sm0 = Xoroshiro128Plus::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoroshiro128Plus::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = Xoroshiro128Plus::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
     }
 }

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -80,7 +80,7 @@ impl TryRng for Xoroshiro128Plus {
         utils::fill_bytes_via_next_word(dest, || self.try_next_u64())
     }
 }
-impl_state_pair!(Xoroshiro128Plus, u64, 16);
+impl_state_pair!(Xoroshiro128Plus, u64);
 
 impl SeedableRng for Xoroshiro128Plus {
     type Seed = [u8; 16];
@@ -134,13 +134,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoroshiro128Plus::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = Xoroshiro128Plus::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = Xoroshiro128Plus::seed_from_u64(42);
+        let clone = Xoroshiro128Plus::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoroshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoroshiro128plusplus.rs
@@ -78,6 +78,8 @@ impl TryRng for Xoroshiro128PlusPlus {
     }
 }
 
+impl_state_pair!(Xoroshiro128PlusPlus, u64, 16);
+
 impl SeedableRng for Xoroshiro128PlusPlus {
     type Seed = [u8; 16];
 
@@ -127,5 +129,17 @@ mod tests {
         let from_zero = Xoroshiro128PlusPlus::from_seed([0u8; 16]);
         let from_sm0 = Xoroshiro128PlusPlus::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoroshiro128PlusPlus::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = Xoroshiro128PlusPlus::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
     }
 }

--- a/rand_xoshiro/src/xoroshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoroshiro128plusplus.rs
@@ -78,7 +78,7 @@ impl TryRng for Xoroshiro128PlusPlus {
     }
 }
 
-impl_state_pair!(Xoroshiro128PlusPlus, u64, 16);
+impl_state_pair!(Xoroshiro128PlusPlus, u64);
 
 impl SeedableRng for Xoroshiro128PlusPlus {
     type Seed = [u8; 16];
@@ -133,13 +133,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoroshiro128PlusPlus::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = Xoroshiro128PlusPlus::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = Xoroshiro128PlusPlus::seed_from_u64(42);
+        let clone = Xoroshiro128PlusPlus::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -78,7 +78,7 @@ impl TryRng for Xoroshiro128StarStar {
     }
 }
 
-impl_state_pair!(Xoroshiro128StarStar, u64, 16);
+impl_state_pair!(Xoroshiro128StarStar, u64);
 
 impl SeedableRng for Xoroshiro128StarStar {
     type Seed = [u8; 16];
@@ -133,13 +133,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoroshiro128StarStar::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = Xoroshiro128StarStar::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = Xoroshiro128StarStar::seed_from_u64(42);
+        let clone = Xoroshiro128StarStar::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -78,6 +78,8 @@ impl TryRng for Xoroshiro128StarStar {
     }
 }
 
+impl_state_pair!(Xoroshiro128StarStar, u64, 16);
+
 impl SeedableRng for Xoroshiro128StarStar {
     type Seed = [u8; 16];
 
@@ -127,5 +129,17 @@ mod tests {
         let from_zero = Xoroshiro128StarStar::from_seed([0u8; 16]);
         let from_sm0 = Xoroshiro128StarStar::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoroshiro128StarStar::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = Xoroshiro128StarStar::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
     }
 }

--- a/rand_xoshiro/src/xoroshiro64star.rs
+++ b/rand_xoshiro/src/xoroshiro64star.rs
@@ -49,7 +49,7 @@ impl TryRng for Xoroshiro64Star {
     }
 }
 
-impl_state_pair!(Xoroshiro64Star, u32, 8);
+impl_state_pair!(Xoroshiro64Star, u32);
 
 impl SeedableRng for Xoroshiro64Star {
     type Seed = [u8; 8];
@@ -102,13 +102,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoroshiro64Star::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u32();
-        }
-        let mut clone = Xoroshiro64Star::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u32(), clone.next_u32());
-        }
+        let rng = Xoroshiro64Star::seed_from_u64(42);
+        let clone = Xoroshiro64Star::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoroshiro64star.rs
+++ b/rand_xoshiro/src/xoroshiro64star.rs
@@ -49,6 +49,8 @@ impl TryRng for Xoroshiro64Star {
     }
 }
 
+impl_state_pair!(Xoroshiro64Star, u32, 8);
+
 impl SeedableRng for Xoroshiro64Star {
     type Seed = [u8; 8];
 
@@ -96,5 +98,17 @@ mod tests {
         let from_zero = Xoroshiro64Star::from_seed([0u8; 8]);
         let from_sm0 = Xoroshiro64Star::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoroshiro64Star::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u32();
+        }
+        let mut clone = Xoroshiro64Star::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u32(), clone.next_u32());
+        }
     }
 }

--- a/rand_xoshiro/src/xoroshiro64starstar.rs
+++ b/rand_xoshiro/src/xoroshiro64starstar.rs
@@ -48,7 +48,7 @@ impl TryRng for Xoroshiro64StarStar {
     }
 }
 
-impl_state_pair!(Xoroshiro64StarStar, u32, 8);
+impl_state_pair!(Xoroshiro64StarStar, u32);
 
 impl SeedableRng for Xoroshiro64StarStar {
     type Seed = [u8; 8];
@@ -101,13 +101,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoroshiro64StarStar::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u32();
-        }
-        let mut clone = Xoroshiro64StarStar::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u32(), clone.next_u32());
-        }
+        let rng = Xoroshiro64StarStar::seed_from_u64(42);
+        let clone = Xoroshiro64StarStar::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoroshiro64starstar.rs
+++ b/rand_xoshiro/src/xoroshiro64starstar.rs
@@ -48,6 +48,8 @@ impl TryRng for Xoroshiro64StarStar {
     }
 }
 
+impl_state_pair!(Xoroshiro64StarStar, u32, 8);
+
 impl SeedableRng for Xoroshiro64StarStar {
     type Seed = [u8; 8];
 
@@ -95,5 +97,17 @@ mod tests {
         let from_zero = Xoroshiro64StarStar::from_seed([0u8; 8]);
         let from_sm0 = Xoroshiro64StarStar::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoroshiro64StarStar::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u32();
+        }
+        let mut clone = Xoroshiro64StarStar::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u32(), clone.next_u32());
+        }
     }
 }

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -56,6 +56,8 @@ impl Xoshiro128Plus {
     }
 }
 
+impl_state_array!(Xoshiro128Plus, u32, 16);
+
 impl SeedableRng for Xoshiro128Plus {
     type Seed = [u8; 16];
 
@@ -142,5 +144,17 @@ mod tests {
         let from_zero = Xoshiro128Plus::from_seed([0u8; 16]);
         let from_sm0 = Xoshiro128Plus::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoshiro128Plus::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u32();
+        }
+        let mut clone = Xoshiro128Plus::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u32(), clone.next_u32());
+        }
     }
 }

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -56,7 +56,7 @@ impl Xoshiro128Plus {
     }
 }
 
-impl_state_array!(Xoshiro128Plus, u32, 16);
+impl_state_array_of_four!(Xoshiro128Plus, u32);
 
 impl SeedableRng for Xoshiro128Plus {
     type Seed = [u8; 16];
@@ -148,13 +148,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoshiro128Plus::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u32();
-        }
-        let mut clone = Xoshiro128Plus::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u32(), clone.next_u32());
-        }
+        let rng = Xoshiro128Plus::seed_from_u64(42);
+        let clone = Xoshiro128Plus::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoshiro128plusplus.rs
@@ -55,7 +55,7 @@ impl Xoshiro128PlusPlus {
     }
 }
 
-impl_state_array!(Xoshiro128PlusPlus, u32, 16);
+impl_state_array_of_four!(Xoshiro128PlusPlus, u32);
 
 impl SeedableRng for Xoshiro128PlusPlus {
     type Seed = [u8; 16];
@@ -150,13 +150,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoshiro128PlusPlus::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u32();
-        }
-        let mut clone = Xoshiro128PlusPlus::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u32(), clone.next_u32());
-        }
+        let rng = Xoshiro128PlusPlus::seed_from_u64(42);
+        let clone = Xoshiro128PlusPlus::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoshiro128plusplus.rs
@@ -55,6 +55,8 @@ impl Xoshiro128PlusPlus {
     }
 }
 
+impl_state_array!(Xoshiro128PlusPlus, u32, 16);
+
 impl SeedableRng for Xoshiro128PlusPlus {
     type Seed = [u8; 16];
 
@@ -144,5 +146,17 @@ mod tests {
         let from_zero = Xoshiro128PlusPlus::from_seed([0u8; 16]);
         let from_sm0 = Xoshiro128PlusPlus::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoshiro128PlusPlus::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u32();
+        }
+        let mut clone = Xoshiro128PlusPlus::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u32(), clone.next_u32());
+        }
     }
 }

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -55,6 +55,8 @@ impl Xoshiro128StarStar {
     }
 }
 
+impl_state_array!(Xoshiro128StarStar, u32, 16);
+
 impl SeedableRng for Xoshiro128StarStar {
     type Seed = [u8; 16];
 
@@ -144,5 +146,17 @@ mod tests {
         let from_zero = Xoshiro128StarStar::from_seed([0u8; 16]);
         let from_sm0 = Xoshiro128StarStar::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoshiro128StarStar::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u32();
+        }
+        let mut clone = Xoshiro128StarStar::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u32(), clone.next_u32());
+        }
     }
 }

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -55,7 +55,7 @@ impl Xoshiro128StarStar {
     }
 }
 
-impl_state_array!(Xoshiro128StarStar, u32, 16);
+impl_state_array_of_four!(Xoshiro128StarStar, u32);
 
 impl SeedableRng for Xoshiro128StarStar {
     type Seed = [u8; 16];
@@ -150,13 +150,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoshiro128StarStar::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u32();
-        }
-        let mut clone = Xoshiro128StarStar::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u32(), clone.next_u32());
-        }
+        let rng = Xoshiro128StarStar::seed_from_u64(42);
+        let clone = Xoshiro128StarStar::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -74,7 +74,7 @@ impl Xoshiro256Plus {
     }
 }
 
-impl_state_array!(Xoshiro256Plus, u64, 32);
+impl_state_array_of_four!(Xoshiro256Plus, u64);
 
 impl SeedableRng for Xoshiro256Plus {
     type Seed = [u8; 32];
@@ -155,13 +155,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoshiro256Plus::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = Xoshiro256Plus::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = Xoshiro256Plus::seed_from_u64(42);
+        let clone = Xoshiro256Plus::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -74,6 +74,8 @@ impl Xoshiro256Plus {
     }
 }
 
+impl_state_array!(Xoshiro256Plus, u64, 32);
+
 impl SeedableRng for Xoshiro256Plus {
     type Seed = [u8; 32];
 
@@ -149,5 +151,17 @@ mod tests {
         let from_zero = Xoshiro256Plus::from_seed([0u8; 32]);
         let from_sm0 = Xoshiro256Plus::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoshiro256Plus::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = Xoshiro256Plus::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
     }
 }

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -73,7 +73,7 @@ impl Xoshiro256PlusPlus {
     }
 }
 
-impl_state_array!(Xoshiro256PlusPlus, u64, 32);
+impl_state_array_of_four!(Xoshiro256PlusPlus, u64);
 
 impl SeedableRng for Xoshiro256PlusPlus {
     type Seed = [u8; 32];
@@ -154,13 +154,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoshiro256PlusPlus::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = Xoshiro256PlusPlus::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = Xoshiro256PlusPlus::seed_from_u64(42);
+        let clone = Xoshiro256PlusPlus::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -73,6 +73,8 @@ impl Xoshiro256PlusPlus {
     }
 }
 
+impl_state_array!(Xoshiro256PlusPlus, u64, 32);
+
 impl SeedableRng for Xoshiro256PlusPlus {
     type Seed = [u8; 32];
 
@@ -148,5 +150,17 @@ mod tests {
         let from_zero = Xoshiro256PlusPlus::from_seed([0; 32]);
         let from_sm0 = Xoshiro256PlusPlus::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoshiro256PlusPlus::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = Xoshiro256PlusPlus::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
     }
 }

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -73,6 +73,8 @@ impl Xoshiro256StarStar {
     }
 }
 
+impl_state_array!(Xoshiro256StarStar, u64, 32);
+
 impl SeedableRng for Xoshiro256StarStar {
     type Seed = [u8; 32];
 
@@ -148,5 +150,17 @@ mod tests {
         let from_zero = Xoshiro256StarStar::from_seed([0u8; 32]);
         let from_sm0 = Xoshiro256StarStar::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoshiro256StarStar::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = Xoshiro256StarStar::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
     }
 }

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -73,7 +73,7 @@ impl Xoshiro256StarStar {
     }
 }
 
-impl_state_array!(Xoshiro256StarStar, u64, 32);
+impl_state_array_of_four!(Xoshiro256StarStar, u64);
 
 impl SeedableRng for Xoshiro256StarStar {
     type Seed = [u8; 32];
@@ -154,13 +154,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoshiro256StarStar::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = Xoshiro256StarStar::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = Xoshiro256StarStar::seed_from_u64(42);
+        let clone = Xoshiro256StarStar::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -84,6 +84,8 @@ impl Xoshiro512Plus {
     }
 }
 
+impl_state_seed512!(Xoshiro512Plus);
+
 impl SeedableRng for Xoshiro512Plus {
     type Seed = Seed512;
 
@@ -161,5 +163,17 @@ mod tests {
         let from_zero = Xoshiro512Plus::from_seed(Seed512([0u8; 64]));
         let from_sm0 = Xoshiro512Plus::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoshiro512Plus::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = Xoshiro512Plus::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
     }
 }

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -167,13 +167,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoshiro512Plus::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = Xoshiro512Plus::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = Xoshiro512Plus::seed_from_u64(42);
+        let clone = Xoshiro512Plus::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -165,13 +165,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoshiro512PlusPlus::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = Xoshiro512PlusPlus::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = Xoshiro512PlusPlus::seed_from_u64(42);
+        let clone = Xoshiro512PlusPlus::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -83,6 +83,8 @@ impl Xoshiro512PlusPlus {
     }
 }
 
+impl_state_seed512!(Xoshiro512PlusPlus);
+
 impl SeedableRng for Xoshiro512PlusPlus {
     type Seed = Seed512;
 
@@ -159,5 +161,17 @@ mod tests {
         let from_zero = Xoshiro512PlusPlus::from_seed(Seed512([0u8; 64]));
         let from_sm0 = Xoshiro512PlusPlus::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoshiro512PlusPlus::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = Xoshiro512PlusPlus::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
     }
 }

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -166,13 +166,8 @@ mod tests {
 
     #[test]
     fn state_roundtrip() {
-        let mut rng = Xoshiro512StarStar::seed_from_u64(42);
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-        let mut clone = Xoshiro512StarStar::from_seed(rng.state());
-        for _ in 0..10 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
-        }
+        let rng = Xoshiro512StarStar::seed_from_u64(42);
+        let clone = Xoshiro512StarStar::from_seed(rng.state());
+        assert_eq!(clone, rng);
     }
 }

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -83,6 +83,8 @@ impl Xoshiro512StarStar {
     }
 }
 
+impl_state_seed512!(Xoshiro512StarStar);
+
 impl SeedableRng for Xoshiro512StarStar {
     type Seed = Seed512;
 
@@ -160,5 +162,17 @@ mod tests {
         let from_zero = Xoshiro512StarStar::from_seed(Seed512([0u8; 64]));
         let from_sm0 = Xoshiro512StarStar::seed_from_u64(0);
         assert_eq!(from_zero, from_sm0);
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        let mut rng = Xoshiro512StarStar::seed_from_u64(42);
+        for _ in 0..10 {
+            rng.next_u64();
+        }
+        let mut clone = Xoshiro512StarStar::from_seed(rng.state());
+        for _ in 0..10 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
     }
 }


### PR DESCRIPTION
Disclaimer: This PR is mostly Claude generated.

Add a `state()` method to all 15 RNG types in `rand_xoshiro`, returning the internal state as a value matching the type's `SeedableRng::Seed`. This lets callers persist and reload generator state without enabling the `serde` feature: `Self::from_seed(rng.state())` reconstructs an identical generator.

Return type per RNG matches its `Seed`:

| RNG                                                       | `state()`   |
| --------------------------------------------------------- | ----------- |
| `SplitMix64`, `Xoroshiro64Star`, `Xoroshiro64StarStar`    | `[u8; 8]`   |
| `Xoroshiro128*`, `Xoshiro128*`                            | `[u8; 16]`  |
| `Xoshiro256*`                                             | `[u8; 32]`  |
| `Xoshiro512*`                                             | `Seed512`   |

The all-zero state is unreachable from any non-zero seed for these algorithms, so the round-trip is exact for any generator obtained via the usual constructors. (`from_seed` remaps an all-zero input to `seed_from_u64(0)`; this is documented on each `state()`.)

Implementation lives in four small macros in `common.rs` (`impl_state_scalar!`, `impl_state_pair!`, `impl_state_array!`, `impl_state_seed512!`); each RNG file gets one macro invocation and one `state_roundtrip` test.

Fixes #109, #64.