### PR TITLE
rand_xoshiro: Shrink all-zero-seed fallback via shared rodata constant

### DIFF
--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Shrink the code size of the all-zero-seed fallback by replacing the per-RNG
+  `SplitMix64::seed_from_u64(0)` call with a single shared constant.
+
 ## [0.8.0] - 2026-02-01
 ### Changes
 - Use Edition 2024 and MSRV 1.85 ([#73])

--- a/rand_xoshiro/src/common.rs
+++ b/rand_xoshiro/src/common.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2026 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -222,19 +222,29 @@ macro_rules! impl_xoshiro_large {
     };
 }
 
-/// Map an all-zero seed to a different one.
-macro_rules! deal_with_zero_seed {
-    ($seed:expr, $Self:ident, $bytes:expr) => {
-        if $seed == [0; $bytes] {
-            return $Self::seed_from_u64(0);
-        }
-    };
+/// Fallback seed used when `from_seed` is called with an all-zero input.
+///
+/// Equal to the first 64 bytes of `SplitMix64::seed_from_u64(0)`'s output.
+/// Smaller generators take a prefix.
+static ZERO_SEED_FALLBACK: [u8; 64] = [
+    0xaf, 0xcd, 0x1d, 0x7b, 0x39, 0xa8, 0x20, 0xe2, 0xf4, 0x65, 0xb9, 0xa1, 0x6a, 0x9e, 0x78, 0x6e,
+    0x4f, 0x45, 0x09, 0x80, 0x18, 0x5d, 0xc4, 0x06, 0xec, 0x81, 0x4c, 0x72, 0xa8, 0xb8, 0x8b, 0xf8,
+    0x9b, 0x74, 0xa8, 0x51, 0x6a, 0x89, 0x39, 0x1b, 0xea, 0xa2, 0x7e, 0x74, 0x0c, 0x9f, 0xcb, 0x53,
+    0xe1, 0x32, 0x45, 0x1f, 0xbe, 0x9a, 0x82, 0x2c, 0x3c, 0xab, 0x16, 0xc9, 0x3a, 0x13, 0x84, 0xc5,
+];
 
-    ($seed:expr, $Self:ident) => {
-        if $seed.iter().all(|&x| x == 0) {
-            return $Self::seed_from_u64(0);
+/// Yield seed bytes for state initialization, swapping in the fallback when
+/// the input is all-zero.
+#[inline]
+pub(crate) const fn zero_seed_fallback<const N: usize>(seed: &[u8; N]) -> &[u8] {
+    let mut i = 0;
+    while i < N {
+        if seed[i] != 0 {
+            return seed;
         }
-    };
+        i += 1;
+    }
+    ZERO_SEED_FALLBACK.split_at(N).0
 }
 
 /// 512-bit seed for a generator.
@@ -272,5 +282,20 @@ impl AsRef<[u8]> for Seed512 {
 impl AsMut<[u8]> for Seed512 {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ZERO_SEED_FALLBACK;
+    use crate::SplitMix64;
+    use rand_core::{Rng, SeedableRng};
+
+    #[test]
+    fn zero_seed_fallback_matches_splitmix() {
+        let mut sm = SplitMix64::seed_from_u64(0);
+        let mut expected = [0u8; 64];
+        sm.fill_bytes(&mut expected);
+        assert_eq!(ZERO_SEED_FALLBACK, expected);
     }
 }

--- a/rand_xoshiro/src/common.rs
+++ b/rand_xoshiro/src/common.rs
@@ -236,15 +236,13 @@ static ZERO_SEED_FALLBACK: [u8; 64] = [
 /// Yield seed bytes for state initialization, swapping in the fallback when
 /// the input is all-zero.
 #[inline]
-pub(crate) const fn zero_seed_fallback<const N: usize>(seed: &[u8; N]) -> &[u8] {
-    let mut i = 0;
-    while i < N {
-        if seed[i] != 0 {
-            return seed;
-        }
-        i += 1;
+pub(crate) fn zero_seed_fallback<const N: usize>(seed: &[u8; N]) -> &[u8; N] {
+    const { assert!(N <= ZERO_SEED_FALLBACK.len()) };
+    if seed.iter().any(|&b| b != 0) {
+        seed
+    } else {
+        ZERO_SEED_FALLBACK.first_chunk::<N>().unwrap()
     }
-    ZERO_SEED_FALLBACK.split_at(N).0
 }
 
 /// 512-bit seed for a generator.

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -86,8 +86,7 @@ impl SeedableRng for Xoroshiro128Plus {
     /// Create a new `Xoroshiro128Plus`.  If `seed` is entirely 0, it will be
     /// mapped to a different seed.
     fn from_seed(seed: [u8; 16]) -> Xoroshiro128Plus {
-        deal_with_zero_seed!(seed, Self, 16);
-        let s: [_; 2] = utils::read_words(&seed);
+        let s: [_; 2] = utils::read_words(crate::common::zero_seed_fallback(&seed));
 
         Xoroshiro128Plus { s0: s[0], s1: s[1] }
     }
@@ -122,5 +121,12 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u64(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoroshiro128Plus::from_seed([0u8; 16]);
+        let from_sm0 = Xoroshiro128Plus::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoroshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoroshiro128plusplus.rs
@@ -84,8 +84,7 @@ impl SeedableRng for Xoroshiro128PlusPlus {
     /// Create a new `Xoroshiro128PlusPlus`.  If `seed` is entirely 0, it will be
     /// mapped to a different seed.
     fn from_seed(seed: [u8; 16]) -> Xoroshiro128PlusPlus {
-        deal_with_zero_seed!(seed, Self, 16);
-        let s: [_; 2] = utils::read_words(&seed);
+        let s: [_; 2] = utils::read_words(crate::common::zero_seed_fallback(&seed));
 
         Xoroshiro128PlusPlus { s0: s[0], s1: s[1] }
     }
@@ -121,5 +120,12 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u64(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoroshiro128PlusPlus::from_seed([0u8; 16]);
+        let from_sm0 = Xoroshiro128PlusPlus::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -84,8 +84,7 @@ impl SeedableRng for Xoroshiro128StarStar {
     /// Create a new `Xoroshiro128StarStar`.  If `seed` is entirely 0, it will be
     /// mapped to a different seed.
     fn from_seed(seed: [u8; 16]) -> Xoroshiro128StarStar {
-        deal_with_zero_seed!(seed, Self, 16);
-        let s: [_; 2] = utils::read_words(&seed);
+        let s: [_; 2] = utils::read_words(crate::common::zero_seed_fallback(&seed));
 
         Xoroshiro128StarStar { s0: s[0], s1: s[1] }
     }
@@ -121,5 +120,12 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u64(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoroshiro128StarStar::from_seed([0u8; 16]);
+        let from_sm0 = Xoroshiro128StarStar::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoroshiro64star.rs
+++ b/rand_xoshiro/src/xoroshiro64star.rs
@@ -55,8 +55,7 @@ impl SeedableRng for Xoroshiro64Star {
     /// Create a new `Xoroshiro64Star`.  If `seed` is entirely 0, it will be
     /// mapped to a different seed.
     fn from_seed(seed: [u8; 8]) -> Xoroshiro64Star {
-        deal_with_zero_seed!(seed, Self, 8);
-        let s: [_; 2] = utils::read_words(&seed);
+        let s: [_; 2] = utils::read_words(crate::common::zero_seed_fallback(&seed));
 
         Xoroshiro64Star { s0: s[0], s1: s[1] }
     }
@@ -90,5 +89,12 @@ mod tests {
     fn zero_seed() {
         let mut rng = Xoroshiro64Star::seed_from_u64(0);
         assert_ne!(rng.next_u64(), 0);
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoroshiro64Star::from_seed([0u8; 8]);
+        let from_sm0 = Xoroshiro64Star::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoroshiro64starstar.rs
+++ b/rand_xoshiro/src/xoroshiro64starstar.rs
@@ -54,8 +54,7 @@ impl SeedableRng for Xoroshiro64StarStar {
     /// Create a new `Xoroshiro64StarStar`.  If `seed` is entirely 0, it will be
     /// mapped to a different seed.
     fn from_seed(seed: [u8; 8]) -> Xoroshiro64StarStar {
-        deal_with_zero_seed!(seed, Self, 8);
-        let s: [_; 2] = utils::read_words(&seed);
+        let s: [_; 2] = utils::read_words(crate::common::zero_seed_fallback(&seed));
 
         Xoroshiro64StarStar { s0: s[0], s1: s[1] }
     }
@@ -89,5 +88,12 @@ mod tests {
     fn zero_seed() {
         let mut rng = Xoroshiro64StarStar::seed_from_u64(0);
         assert_ne!(rng.next_u64(), 0);
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoroshiro64StarStar::from_seed([0u8; 8]);
+        let from_sm0 = Xoroshiro64StarStar::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -63,9 +63,8 @@ impl SeedableRng for Xoshiro128Plus {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: [u8; 16]) -> Xoshiro128Plus {
-        deal_with_zero_seed!(seed, Self, 16);
         Xoshiro128Plus {
-            s: utils::read_words(&seed),
+            s: utils::read_words(crate::common::zero_seed_fallback(&seed)),
         }
     }
 
@@ -136,5 +135,12 @@ mod tests {
         assert_eq!(rng.s[1], 2125834322);
         assert_eq!(rng.s[2], 966769569);
         assert_eq!(rng.s[3], 3193880526);
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoshiro128Plus::from_seed([0u8; 16]);
+        let from_sm0 = Xoshiro128Plus::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoshiro128plusplus.rs
@@ -62,9 +62,8 @@ impl SeedableRng for Xoshiro128PlusPlus {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: [u8; 16]) -> Xoshiro128PlusPlus {
-        deal_with_zero_seed!(seed, Self, 16);
         Xoshiro128PlusPlus {
-            s: utils::read_words(&seed),
+            s: utils::read_words(crate::common::zero_seed_fallback(&seed)),
         }
     }
 
@@ -138,5 +137,12 @@ mod tests {
         assert_eq!(rng.s[1], 2125834322);
         assert_eq!(rng.s[2], 966769569);
         assert_eq!(rng.s[3], 3193880526);
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoshiro128PlusPlus::from_seed([0u8; 16]);
+        let from_sm0 = Xoshiro128PlusPlus::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -62,9 +62,8 @@ impl SeedableRng for Xoshiro128StarStar {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: [u8; 16]) -> Xoshiro128StarStar {
-        deal_with_zero_seed!(seed, Self, 16);
         Xoshiro128StarStar {
-            s: utils::read_words(&seed),
+            s: utils::read_words(crate::common::zero_seed_fallback(&seed)),
         }
     }
 
@@ -138,5 +137,12 @@ mod tests {
         assert_eq!(rng.s[1], 2125834322);
         assert_eq!(rng.s[2], 966769569);
         assert_eq!(rng.s[3], 3193880526);
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoshiro128StarStar::from_seed([0u8; 16]);
+        let from_sm0 = Xoshiro128StarStar::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -81,9 +81,8 @@ impl SeedableRng for Xoshiro256Plus {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: [u8; 32]) -> Xoshiro256Plus {
-        deal_with_zero_seed!(seed, Self);
         Xoshiro256Plus {
-            s: utils::read_words(&seed),
+            s: utils::read_words(crate::common::zero_seed_fallback(&seed)),
         }
     }
 
@@ -143,5 +142,12 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u64(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoshiro256Plus::from_seed([0u8; 32]);
+        let from_sm0 = Xoshiro256Plus::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -80,9 +80,8 @@ impl SeedableRng for Xoshiro256PlusPlus {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: [u8; 32]) -> Xoshiro256PlusPlus {
-        deal_with_zero_seed!(seed, Self);
         Xoshiro256PlusPlus {
-            s: utils::read_words(&seed),
+            s: utils::read_words(crate::common::zero_seed_fallback(&seed)),
         }
     }
 
@@ -142,5 +141,12 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u64(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoshiro256PlusPlus::from_seed([0; 32]);
+        let from_sm0 = Xoshiro256PlusPlus::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -80,9 +80,8 @@ impl SeedableRng for Xoshiro256StarStar {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: [u8; 32]) -> Xoshiro256StarStar {
-        deal_with_zero_seed!(seed, Self);
         Xoshiro256StarStar {
-            s: utils::read_words(&seed),
+            s: utils::read_words(crate::common::zero_seed_fallback(&seed)),
         }
     }
 
@@ -142,5 +141,12 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u64(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoshiro256StarStar::from_seed([0u8; 32]);
+        let from_sm0 = Xoshiro256StarStar::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -91,9 +91,8 @@ impl SeedableRng for Xoshiro512Plus {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: Seed512) -> Xoshiro512Plus {
-        deal_with_zero_seed!(seed, Self);
         Xoshiro512Plus {
-            s: utils::read_words(seed.as_ref()),
+            s: utils::read_words(crate::common::zero_seed_fallback(&seed.0)),
         }
     }
 
@@ -155,5 +154,12 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u64(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoshiro512Plus::from_seed(Seed512([0u8; 64]));
+        let from_sm0 = Xoshiro512Plus::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -90,9 +90,8 @@ impl SeedableRng for Xoshiro512PlusPlus {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: Seed512) -> Xoshiro512PlusPlus {
-        deal_with_zero_seed!(seed, Self);
         Xoshiro512PlusPlus {
-            s: utils::read_words(seed.as_ref()),
+            s: utils::read_words(crate::common::zero_seed_fallback(&seed.0)),
         }
     }
 
@@ -153,5 +152,12 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u64(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoshiro512PlusPlus::from_seed(Seed512([0u8; 64]));
+        let from_sm0 = Xoshiro512PlusPlus::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -90,9 +90,8 @@ impl SeedableRng for Xoshiro512StarStar {
     /// mapped to a different seed.
     #[inline]
     fn from_seed(seed: Seed512) -> Xoshiro512StarStar {
-        deal_with_zero_seed!(seed, Self);
         Xoshiro512StarStar {
-            s: utils::read_words(seed.as_ref()),
+            s: utils::read_words(crate::common::zero_seed_fallback(&seed.0)),
         }
     }
 
@@ -154,5 +153,12 @@ mod tests {
         for &e in &expected {
             assert_eq!(rng.next_u64(), e);
         }
+    }
+
+    #[test]
+    fn zero_seed_maps_to_seed_from_u64_zero() {
+        let from_zero = Xoshiro512StarStar::from_seed(Seed512([0u8; 64]));
+        let from_sm0 = Xoshiro512StarStar::seed_from_u64(0);
+        assert_eq!(from_zero, from_sm0);
     }
 }


### PR DESCRIPTION
Replace the per-RNG `SplitMix64::seed_from_u64(0)` cold call with a single 64-byte `ZERO_SEED_FALLBACK` static.

Reduces combined `.text + .rodata` by 496 B on a small binary that exercises every `from_seed`, and shrinks each call site by 8 B. The all-zero-seed output is byte-identical to the previous behavior; a new `zero_seed_fallback_matches_splitmix` test derives the static at runtime and asserts equality, and each RNG has a new `zero_seed_maps_to_seed_from_u64_zero` test pinning the remap.

Removing the check entirely would save 51 B at the call site, and 592 B in `.text + .rodata` (see #107).