### PR TITLE
Deprecate rand_isaac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "rand_isaac"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "postcard",
  "rand_core",

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -38,7 +38,6 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "rand_hc",
- "rand_isaac",
  "rand_sfc",
  "rand_xorshift",
  "rand_xoshiro",
@@ -340,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.10.0-rc.6"
+version = "0.10.0"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -348,41 +347,34 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-6"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70765ff7112b0fb2d272d24d9a2f907fc206211304328fe58b2db15a5649ef28"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
-version = "0.5.0-rc.0"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "rand_sfc"
-version = "0.2.0-rc.0"
+version = "0.2.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.8.0-rc.0"
+version = "0.8.1"
 dependencies = [
  "rand_core",
 ]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,7 +11,6 @@ criterion-cycles-per-byte = "0.6"
 rand_core = "0.10.0"
 rand_chacha = { path = "../rand_chacha", version = "0.10.0-rc.6" }
 rand_xoshiro = { path = "../rand_xoshiro", version = "0.8.0-rc.0" }
-rand_isaac = { path = "../rand_isaac", version = "0.5.0-rc.0" }
 rand_xorshift = { path = "../rand_xorshift", version = "0.5.0-rc.0" }
 rand_hc = { path = "../rand_hc", version = "0.5.0-rc.0" }
 rand_sfc = { path = "../rand_sfc", version = "0.2.0-rc.0" }

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -20,7 +20,6 @@ use rand_core::{Rng, SeedableRng};
 
 use rand_chacha::{ChaCha8Rng, ChaCha12Rng, ChaCha20Rng};
 use rand_hc::Hc128Rng;
-use rand_isaac::{Isaac64Rng, IsaacRng};
 use rand_sfc::{Sfc32, Sfc64};
 use rand_xorshift::XorShiftRng;
 use rand_xoshiro::{
@@ -84,8 +83,6 @@ fn gen_bytes(c: &mut Criterion<CyclesPerByte>) {
     gen_bytes!("xoroshiro64star", Xoroshiro64Star::from_rng(&mut master));
     gen_bytes!("splitmix64", SplitMix64::from_rng(&mut master));
     gen_bytes!("hc128", Hc128Rng::from_rng(&mut master));
-    gen_bytes!("isaac", IsaacRng::from_rng(&mut master));
-    gen_bytes!("isaac64", Isaac64Rng::from_rng(&mut master));
     gen_bytes!("sfc32", Sfc32::from_rng(&mut master));
     gen_bytes!("sfc64", Sfc64::from_rng(&mut master));
     gen_bytes!("chacha8", ChaCha8Rng::from_rng(&mut master));
@@ -197,8 +194,6 @@ fn gen_uint(c: &mut Criterion<CyclesPerByte>) {
         );
         gen_uint!(g, "splitmix64", u32, SplitMix64::from_rng(&mut master));
         gen_uint!(g, "hc128", u32, Hc128Rng::from_rng(&mut master));
-        gen_uint!(g, "isaac", u32, IsaacRng::from_rng(&mut master));
-        gen_uint!(g, "isaac64", u32, Isaac64Rng::from_rng(&mut master));
         gen_uint!(g, "sfc32", u32, Sfc32::from_rng(&mut master));
         gen_uint!(g, "sfc64", u32, Sfc64::from_rng(&mut master));
         gen_uint!(g, "chacha8", u32, ChaCha8Rng::from_rng(&mut master));
@@ -273,8 +268,6 @@ fn gen_uint(c: &mut Criterion<CyclesPerByte>) {
         );
         gen_uint!(g, "splitmix64", u64, SplitMix64::from_rng(&mut master));
         gen_uint!(g, "hc128", u64, Hc128Rng::from_rng(&mut master));
-        gen_uint!(g, "isaac", u64, IsaacRng::from_rng(&mut master));
-        gen_uint!(g, "isaac64", u64, Isaac64Rng::from_rng(&mut master));
         gen_uint!(g, "sfc32", u64, Sfc32::from_rng(&mut master));
         gen_uint!(g, "sfc64", u64, Sfc64::from_rng(&mut master));
         gen_uint!(g, "chacha8", u64, ChaCha8Rng::from_rng(&mut master));
@@ -309,8 +302,6 @@ fn init(c: &mut Criterion) {
     init_gen!("xoroshiro64star", Xoroshiro64Star);
     init_gen!("splitmix64", SplitMix64);
     init_gen!("hc128", Hc128Rng);
-    init_gen!("isaac", IsaacRng);
-    init_gen!("isaac64", Isaac64Rng);
     init_gen!("sfc32", Sfc32);
     init_gen!("sfc64", Sfc64);
     init_gen!("chacha8", ChaCha8Rng);

--- a/rand_isaac/CHANGELOG.md
+++ b/rand_isaac/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-05-19
+Deprecate crate `rand_isaac` ([#113]).
+
+[#113]: https://github.com/rust-random/rngs/pull/113
+
 ## [0.5.0] - 2026-02-01
 ### Value-breaking changes
 - Drop use of half-used words in `Isaac64Rng::next_u32` ([#82])

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_isaac"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rand_isaac/src/lib.rs
+++ b/rand_isaac/src/lib.rs
@@ -23,6 +23,10 @@
     clippy::identity_op
 )]
 #![cfg_attr(not(all(feature = "serde", test)), no_std)]
+#![deprecated(
+    since = "0.5.1",
+    note = "The rand_isaac crate is no longer maintained; we suggest switching to chacha20 or rand_hc"
+)]
 
 pub mod isaac;
 pub mod isaac64;


### PR DESCRIPTION
This allows us to publish a deprecation warning. We can delete the code from the repository later (e.g. when preparing for the next rand_core release).

Closes #98.