### PR TITLE
Added jump_ce/jump_n to xoshiro/xoroshiro generators with jumps

### DIFF
--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `jump_n(c, e)` on every xoshiro/xoroshiro generator that has `jump()`,
+- `jump_ce(c, e)` on every xoshiro/xoroshiro generator that has `jump()`,
   jumping ahead by c · 2^e steps via the jump polynomial x^(c · 2^e) mod p(x).
+- `jump_n(jump)` on the same generators, jumping ahead by the arbitrary
+  little-endian distance held in `jump` (a `[u64; N]` matching the state words).
+  Unlike `jump_ce`, it can express any jump distance up to the period.
 
 ## [0.8.1] - 2026-05-16
 ### Added

--- a/rand_xoshiro/CHANGELOG.md
+++ b/rand_xoshiro/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `jump_n(c, e)` on every xoshiro/xoroshiro generator that has `jump()`,
+  jumping ahead by c · 2^e steps via the jump polynomial x^(c · 2^e) mod p(x).
+
 ## [0.8.1] - 2026-05-16
 ### Added
 - `state()` method on every RNG type returning the internal state as a value

--- a/rand_xoshiro/src/common.rs
+++ b/rand_xoshiro/src/common.rs
@@ -143,6 +143,96 @@ macro_rules! impl_jump {
     };
 }
 
+/// Implement an arbitrary-jump function (`jump_n`) for an RNG from the xoshiro
+/// family.
+macro_rules! impl_jump_n {
+    (u64, $self:expr, $charpoly:expr, $c:expr, $e:expr, array4) => {
+        let mut poly = [0; 4];
+        crate::f2x::jump_poly($c, $e, &$charpoly, &mut poly);
+        let mut s0 = 0;
+        let mut s1 = 0;
+        let mut s2 = 0;
+        let mut s3 = 0;
+        for word in poly {
+            for b in 0..64 {
+                if (word >> b) & 1 != 0 {
+                    s0 ^= $self.s[0];
+                    s1 ^= $self.s[1];
+                    s2 ^= $self.s[2];
+                    s3 ^= $self.s[3];
+                }
+                $self.next_u64();
+            }
+        }
+        $self.s[0] = s0;
+        $self.s[1] = s1;
+        $self.s[2] = s2;
+        $self.s[3] = s3;
+    };
+    (u64, $self:expr, $charpoly:expr, $c:expr, $e:expr, array8) => {
+        let mut poly = [0; 8];
+        crate::f2x::jump_poly($c, $e, &$charpoly, &mut poly);
+        let mut s = [0; 8];
+        for word in poly {
+            for b in 0..64 {
+                if (word >> b) & 1 != 0 {
+                    s[0] ^= $self.s[0];
+                    s[1] ^= $self.s[1];
+                    s[2] ^= $self.s[2];
+                    s[3] ^= $self.s[3];
+                    s[4] ^= $self.s[4];
+                    s[5] ^= $self.s[5];
+                    s[6] ^= $self.s[6];
+                    s[7] ^= $self.s[7];
+                }
+                $self.next_u64();
+            }
+        }
+        $self.s = s;
+    };
+    (u64, $self:expr, $charpoly:expr, $c:expr, $e:expr, pair) => {
+        let mut poly = [0; 2];
+        crate::f2x::jump_poly($c, $e, &$charpoly, &mut poly);
+        let mut s0 = 0;
+        let mut s1 = 0;
+        for word in poly {
+            for b in 0..64 {
+                if (word >> b) & 1 != 0 {
+                    s0 ^= $self.s0;
+                    s1 ^= $self.s1;
+                }
+                $self.next_u64();
+            }
+        }
+        $self.s0 = s0;
+        $self.s1 = s1;
+    };
+    (u32, $self:expr, $charpoly:expr, $c:expr, $e:expr, array4) => {
+        // 128 bits of state = 4 × u32 = 2 × u64 polynomial words.
+        let mut poly = [0; 2];
+        crate::f2x::jump_poly($c, $e, &$charpoly, &mut poly);
+        let mut s0 = 0;
+        let mut s1 = 0;
+        let mut s2 = 0;
+        let mut s3 = 0;
+        for word in poly {
+            for b in 0..64 {
+                if (word >> b) & 1 != 0 {
+                    s0 ^= $self.s[0];
+                    s1 ^= $self.s[1];
+                    s2 ^= $self.s[2];
+                    s3 ^= $self.s[3];
+                }
+                $self.next_u32();
+            }
+        }
+        $self.s[0] = s0;
+        $self.s[1] = s1;
+        $self.s[2] = s2;
+        $self.s[3] = s3;
+    };
+}
+
 /// Implement the xoroshiro iteration.
 macro_rules! impl_xoroshiro_u32 {
     ($self:expr) => {

--- a/rand_xoshiro/src/common.rs
+++ b/rand_xoshiro/src/common.rs
@@ -143,17 +143,16 @@ macro_rules! impl_jump {
     };
 }
 
-/// Implement an arbitrary-jump function (`jump_n`) for an RNG from the xoshiro
-/// family.
-macro_rules! impl_jump_n {
-    (u64, $self:expr, $charpoly:expr, $c:expr, $e:expr, array4) => {
-        let mut poly = [0; 4];
-        crate::f2x::jump_poly($c, $e, &$charpoly, &mut poly);
+/// Apply a precomputed jump polynomial `poly` (= x^n mod charpoly for the
+/// desired distance n) to the state, using the same accumulate-and-step loop as
+/// [`impl_jump`]. Shared by the `jump_ce` and `jump_n` methods.
+macro_rules! apply_jump_poly {
+    (u64, $self:expr, $poly:expr, array4) => {
         let mut s0 = 0;
         let mut s1 = 0;
         let mut s2 = 0;
         let mut s3 = 0;
-        for word in poly {
+        for word in $poly {
             for b in 0..64 {
                 if (word >> b) & 1 != 0 {
                     s0 ^= $self.s[0];
@@ -169,11 +168,9 @@ macro_rules! impl_jump_n {
         $self.s[2] = s2;
         $self.s[3] = s3;
     };
-    (u64, $self:expr, $charpoly:expr, $c:expr, $e:expr, array8) => {
-        let mut poly = [0; 8];
-        crate::f2x::jump_poly($c, $e, &$charpoly, &mut poly);
+    (u64, $self:expr, $poly:expr, array8) => {
         let mut s = [0; 8];
-        for word in poly {
+        for word in $poly {
             for b in 0..64 {
                 if (word >> b) & 1 != 0 {
                     s[0] ^= $self.s[0];
@@ -190,12 +187,10 @@ macro_rules! impl_jump_n {
         }
         $self.s = s;
     };
-    (u64, $self:expr, $charpoly:expr, $c:expr, $e:expr, pair) => {
-        let mut poly = [0; 2];
-        crate::f2x::jump_poly($c, $e, &$charpoly, &mut poly);
+    (u64, $self:expr, $poly:expr, pair) => {
         let mut s0 = 0;
         let mut s1 = 0;
-        for word in poly {
+        for word in $poly {
             for b in 0..64 {
                 if (word >> b) & 1 != 0 {
                     s0 ^= $self.s0;
@@ -207,15 +202,12 @@ macro_rules! impl_jump_n {
         $self.s0 = s0;
         $self.s1 = s1;
     };
-    (u32, $self:expr, $charpoly:expr, $c:expr, $e:expr, array4) => {
-        // 128 bits of state = 4 × u32 = 2 × u64 polynomial words.
-        let mut poly = [0; 2];
-        crate::f2x::jump_poly($c, $e, &$charpoly, &mut poly);
+    (u32, $self:expr, $poly:expr, array4) => {
         let mut s0 = 0;
         let mut s1 = 0;
         let mut s2 = 0;
         let mut s3 = 0;
-        for word in poly {
+        for word in $poly {
             for b in 0..64 {
                 if (word >> b) & 1 != 0 {
                     s0 ^= $self.s[0];
@@ -230,6 +222,53 @@ macro_rules! impl_jump_n {
         $self.s[1] = s1;
         $self.s[2] = s2;
         $self.s[3] = s3;
+    };
+}
+
+/// Number of `u64` polynomial words for a state-shape tag.
+macro_rules! poly_words {
+    (array8) => {
+        8
+    };
+    (array4) => {
+        4
+    };
+    // 128 bits of state = 2 × u64 polynomial words (4 × u32 or a `u64` pair).
+    (array4_u32) => {
+        2
+    };
+    (pair) => {
+        2
+    };
+}
+
+/// Implement the `c · 2^e` arbitrary-jump function (`jump_ce`) for an RNG from
+/// the xoshiro family.
+macro_rules! impl_jump_ce {
+    (u32, $self:expr, $charpoly:expr, $c:expr, $e:expr, array4) => {
+        let mut poly = [0; poly_words!(array4_u32)];
+        crate::f2x::jump_poly_ce($c, $e, &$charpoly, &mut poly);
+        apply_jump_poly!(u32, $self, poly, array4);
+    };
+    (u64, $self:expr, $charpoly:expr, $c:expr, $e:expr, $shape:tt) => {
+        let mut poly = [0; poly_words!($shape)];
+        crate::f2x::jump_poly_ce($c, $e, &$charpoly, &mut poly);
+        apply_jump_poly!(u64, $self, poly, $shape);
+    };
+}
+
+/// Implement the general arbitrary-jump function (`jump_n`) for an RNG from the
+/// xoshiro family. The distance is the little-endian integer held in `$jump`.
+macro_rules! impl_jump_n {
+    (u32, $self:expr, $charpoly:expr, $jump:expr, array4) => {
+        let mut poly = [0; poly_words!(array4_u32)];
+        crate::f2x::jump_poly_n($jump, &$charpoly, &mut poly);
+        apply_jump_poly!(u32, $self, poly, array4);
+    };
+    (u64, $self:expr, $charpoly:expr, $jump:expr, $shape:tt) => {
+        let mut poly = [0; poly_words!($shape)];
+        crate::f2x::jump_poly_n($jump, &$charpoly, &mut poly);
+        apply_jump_poly!(u64, $self, poly, $shape);
     };
 }
 

--- a/rand_xoshiro/src/f2x.rs
+++ b/rand_xoshiro/src/f2x.rs
@@ -8,7 +8,7 @@
 
 //! Minimal arithmetic in F₂[*x*] / (charpoly), the ring in which advancing a
 //! linear generator by one step is multiplication by *x*. Used to compute the
-//! jump polynomial for the `jump_n` methods.
+//! jump polynomial for the `jump_ce` and `jump_n` methods.
 //!
 //! `charpoly` holds the `deg` low coefficients of the characteristic polynomial
 //! (`deg = 64 * charpoly.len()`); the leading `x^deg` term is implicit. All
@@ -56,7 +56,7 @@ fn mul_mod(a: &mut [u64], b: &[u64], charpoly: &[u64]) {
 
 /// `out <- x^(c · 2^e) mod charpoly`, by square-and-multiply. Requires
 /// `out.len() == charpoly.len()`.
-pub(crate) fn jump_poly(c: u64, e: u64, charpoly: &[u64], out: &mut [u64]) {
+pub(crate) fn jump_poly_ce(c: u64, e: u32, charpoly: &[u64], out: &mut [u64]) {
     let w = charpoly.len();
     for o in out.iter_mut() {
         *o = 0;
@@ -79,9 +79,30 @@ pub(crate) fn jump_poly(c: u64, e: u64, charpoly: &[u64], out: &mut [u64]) {
     }
 }
 
+/// `out <- x^n mod charpoly`, where `n = jump[0] + jump[1] · 2^64 + …` is the
+/// little-endian integer held in the `N` words of `jump`. Square-and-multiply
+/// over the bits of `n`, from the most significant down. Requires
+/// `out.len() == charpoly.len()`.
+pub(crate) fn jump_poly_n<const N: usize>(jump: &[u64; N], charpoly: &[u64], out: &mut [u64]) {
+    let w = charpoly.len();
+    for o in out.iter_mut() {
+        *o = 0;
+    }
+    out[0] = 1; // out = 1
+    for k in (0..N * 64).rev() {
+        // out = out^2
+        let mut sq = [0; 8];
+        sq[..w].copy_from_slice(&out[..w]);
+        mul_mod(out, &sq[..w], charpoly);
+        if (jump[k >> 6] >> (k & 63)) & 1 != 0 {
+            mul_x(out, charpoly);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{jump_poly, mul_x};
+    use super::{jump_poly_ce, jump_poly_n, mul_x};
 
     // xoshiro256 characteristic polynomial.
     const P: [u64; 4] = [
@@ -101,51 +122,75 @@ mod tests {
     }
 
     #[test]
-    fn jump_poly_matches_repeated_mul_x_for_e0() {
+    fn jump_poly_ce_matches_repeated_mul_x_for_e0() {
         for &c in &[0, 1, 2, 3, 7, 64, 1000, 5000] {
             let mut out = [0; 4];
-            jump_poly(c, 0, &P, &mut out);
-            assert_eq!(out, x_pow(c), "jump_poly({c}, 0)");
+            jump_poly_ce(c, 0, &P, &mut out);
+            assert_eq!(out, x_pow(c), "jump_poly_ce({c}, 0)");
         }
     }
 
     #[test]
-    fn jump_poly_matches_repeated_mul_x_for_powers_of_two() {
-        // jump_poly(1, e) == x^(2^e); compare to 2^e applications of mul_x.
+    fn jump_poly_ce_matches_repeated_mul_x_for_powers_of_two() {
+        // jump_poly_ce(1, e) == x^(2^e); compare to 2^e applications of mul_x.
         for e in 0..=12 {
             let mut out = [0; 4];
-            jump_poly(1, e, &P, &mut out);
-            assert_eq!(out, x_pow(1 << e), "jump_poly(1, {e})");
+            jump_poly_ce(1, e, &P, &mut out);
+            assert_eq!(out, x_pow(1 << e), "jump_poly_ce(1, {e})");
         }
     }
 
     #[test]
     fn x_pow_zero_is_one() {
         let mut out = [0; 4];
-        jump_poly(0, 0, &P, &mut out);
+        jump_poly_ce(0, 0, &P, &mut out);
         assert_eq!(out, [1, 0, 0, 0]);
     }
 
     #[test]
-    fn jump_poly_consistency_under_current_build() {
+    fn jump_poly_ce_consistency_under_current_build() {
         // x^300 * x^45 == x^345.
         let mut g = [0; 4];
-        jump_poly(300, 0, &P, &mut g);
+        jump_poly_ce(300, 0, &P, &mut g);
         for _ in 0..45 {
             mul_x(&mut g, &P);
         }
         let mut expect = [0; 4];
-        jump_poly(345, 0, &P, &mut expect);
+        jump_poly_ce(345, 0, &P, &mut expect);
         assert_eq!(g, expect);
     }
 
     #[test]
-    fn jump_poly_c_and_e_combined() {
-        // jump_poly(c, e) == x^(c * 2^e); exercises the combined exponent path.
+    fn jump_poly_ce_c_and_e_combined() {
+        // jump_poly_ce(c, e) == x^(c * 2^e); exercises the combined exponent path.
         for &(c, e) in &[(3, 8), (5, 4), (7, 10)] {
             let mut out = [0; 4];
-            jump_poly(c, e, &P, &mut out);
-            assert_eq!(out, x_pow(c << e), "jump_poly({c}, {e})");
+            jump_poly_ce(c, e, &P, &mut out);
+            assert_eq!(out, x_pow(c << e), "jump_poly_ce({c}, {e})");
+        }
+    }
+
+    #[test]
+    fn jump_poly_n_matches_ce_single_word() {
+        // jump_poly_n(&[n]) == jump_poly_ce(n, 0) for a single-word distance.
+        for &n in &[0, 1, 2, 3, 7, 64, 1000, 5000] {
+            let mut got = [0; 4];
+            jump_poly_n(&[n], &P, &mut got);
+            let mut expect = [0; 4];
+            jump_poly_ce(n, 0, &P, &mut expect);
+            assert_eq!(got, expect, "jump_poly_n(&[{n}])");
+        }
+    }
+
+    #[test]
+    fn jump_poly_n_matches_ce_multi_word() {
+        // n = c * 2^64 is the two-word integer [0, c]; compare to ce(c, 64).
+        for &c in &[1, 3, 5000] {
+            let mut got = [0; 4];
+            jump_poly_n(&[0, c], &P, &mut got);
+            let mut expect = [0; 4];
+            jump_poly_ce(c, 64, &P, &mut expect);
+            assert_eq!(got, expect, "jump_poly_n(&[0, {c}])");
         }
     }
 }

--- a/rand_xoshiro/src/f2x.rs
+++ b/rand_xoshiro/src/f2x.rs
@@ -85,6 +85,7 @@ pub(crate) fn jump_poly_ce(c: u64, e: u32, charpoly: &[u64], out: &mut [u64]) {
 /// over the bits of `n`, from the most significant down. Requires
 /// `out.len() == charpoly.len()`.
 pub(crate) fn jump_poly_n<const N: usize>(jump: &[u64; N], charpoly: &[u64], out: &mut [u64]) {
+    debug_assert_eq!(out.len(), charpoly.len());
     let w = charpoly.len();
     for o in out.iter_mut() {
         *o = 0;

--- a/rand_xoshiro/src/f2x.rs
+++ b/rand_xoshiro/src/f2x.rs
@@ -1,0 +1,151 @@
+// Copyright 2018-2026 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Minimal arithmetic in F₂[*x*] / (charpoly), the ring in which advancing a
+//! linear generator by one step is multiplication by *x*. Used to compute the
+//! jump polynomial for the `jump_n` methods.
+//!
+//! `charpoly` holds the `deg` low coefficients of the characteristic polynomial
+//! (`deg = 64 * charpoly.len()`); the leading `x^deg` term is implicit. All
+//! supported generators have a state that is a whole number of `u64` words, so
+//! `deg` is a multiple of 64.
+
+/// Coefficient `k` of the polynomial stored in `a`.
+#[inline]
+fn bit(a: &[u64], k: usize) -> u64 {
+    (a[k / 64] >> (k & 63)) & 1
+}
+
+/// `a <- a · x mod charpoly`, in place. Requires `a.len() == charpoly.len()`.
+pub(crate) fn mul_x(a: &mut [u64], charpoly: &[u64]) {
+    let mut carry = 0;
+    for word in a.iter_mut() {
+        let next_carry = *word >> 63;
+        *word = (*word << 1) | carry;
+        carry = next_carry;
+    }
+    // All supported degrees are multiples of 64, so the x^deg coefficient is
+    // exactly the carry out of the top word.
+    if carry != 0 {
+        for (w, &p) in a.iter_mut().zip(charpoly) {
+            *w ^= p;
+        }
+    }
+}
+
+/// `a <- a · b mod charpoly`.
+fn mul_mod(a: &mut [u64], b: &[u64], charpoly: &[u64]) {
+    let w = charpoly.len();
+    let deg = 64 * w;
+    let mut r = [0; 8];
+    for k in (0..deg).rev() {
+        mul_x(&mut r[..w], charpoly);
+        if bit(a, k) != 0 {
+            for i in 0..w {
+                r[i] ^= b[i];
+            }
+        }
+    }
+    a[..w].copy_from_slice(&r[..w]);
+}
+
+/// `out <- x^(c · 2^e) mod charpoly`, by square-and-multiply. Requires
+/// `out.len() == charpoly.len()`.
+pub(crate) fn jump_poly(c: u64, e: u64, charpoly: &[u64], out: &mut [u64]) {
+    let w = charpoly.len();
+    for o in out.iter_mut() {
+        *o = 0;
+    }
+    out[0] = 1; // out = 1
+    for k in (0..64).rev() {
+        // out = out^2
+        let mut sq = [0; 8];
+        sq[..w].copy_from_slice(&out[..w]);
+        mul_mod(out, &sq[..w], charpoly);
+        if (c >> k) & 1 != 0 {
+            mul_x(out, charpoly);
+        }
+    }
+    // out = (x^c)^(2^e) = x^(c · 2^e)
+    for _ in 0..e {
+        let mut sq = [0; 8];
+        sq[..w].copy_from_slice(&out[..w]);
+        mul_mod(out, &sq[..w], charpoly);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{jump_poly, mul_x};
+
+    // xoshiro256 characteristic polynomial.
+    const P: [u64; 4] = [
+        0x9d116f2bb0f0f001,
+        0x0280002bcefd1a5e,
+        0x04b4edcf26259f85,
+        0x0003c03c3f3ecb19,
+    ];
+
+    // x^c mod p by applying mul_x c times to the constant 1.
+    fn x_pow(c: u64) -> [u64; 4] {
+        let mut a = [1, 0, 0, 0];
+        for _ in 0..c {
+            mul_x(&mut a, &P);
+        }
+        a
+    }
+
+    #[test]
+    fn jump_poly_matches_repeated_mul_x_for_e0() {
+        for &c in &[0, 1, 2, 3, 7, 64, 1000, 5000] {
+            let mut out = [0; 4];
+            jump_poly(c, 0, &P, &mut out);
+            assert_eq!(out, x_pow(c), "jump_poly({c}, 0)");
+        }
+    }
+
+    #[test]
+    fn jump_poly_matches_repeated_mul_x_for_powers_of_two() {
+        // jump_poly(1, e) == x^(2^e); compare to 2^e applications of mul_x.
+        for e in 0..=12 {
+            let mut out = [0; 4];
+            jump_poly(1, e, &P, &mut out);
+            assert_eq!(out, x_pow(1 << e), "jump_poly(1, {e})");
+        }
+    }
+
+    #[test]
+    fn x_pow_zero_is_one() {
+        let mut out = [0; 4];
+        jump_poly(0, 0, &P, &mut out);
+        assert_eq!(out, [1, 0, 0, 0]);
+    }
+
+    #[test]
+    fn jump_poly_consistency_under_current_build() {
+        // x^300 * x^45 == x^345.
+        let mut g = [0; 4];
+        jump_poly(300, 0, &P, &mut g);
+        for _ in 0..45 {
+            mul_x(&mut g, &P);
+        }
+        let mut expect = [0; 4];
+        jump_poly(345, 0, &P, &mut expect);
+        assert_eq!(g, expect);
+    }
+
+    #[test]
+    fn jump_poly_c_and_e_combined() {
+        // jump_poly(c, e) == x^(c * 2^e); exercises the combined exponent path.
+        for &(c, e) in &[(3, 8), (5, 4), (7, 10)] {
+            let mut out = [0; 4];
+            jump_poly(c, e, &P, &mut out);
+            assert_eq!(out, x_pow(c << e), "jump_poly({c}, {e})");
+        }
+    }
+}

--- a/rand_xoshiro/src/f2x.rs
+++ b/rand_xoshiro/src/f2x.rs
@@ -23,6 +23,7 @@ fn bit(a: &[u64], k: usize) -> u64 {
 
 /// `a <- a · x mod charpoly`, in place. Requires `a.len() == charpoly.len()`.
 pub(crate) fn mul_x(a: &mut [u64], charpoly: &[u64]) {
+    debug_assert_eq!(a.len(), charpoly.len());
     let mut carry = 0;
     for word in a.iter_mut() {
         let next_carry = *word >> 63;

--- a/rand_xoshiro/src/lib.rs
+++ b/rand_xoshiro/src/lib.rs
@@ -92,6 +92,7 @@
 
 #[macro_use]
 mod common;
+mod f2x;
 mod splitmix64;
 mod xoroshiro128plus;
 mod xoroshiro128plusplus;

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -59,17 +59,38 @@ impl Xoroshiro128Plus {
 
     /// Jump forward by c · 2^e calls to `next_u64()`.
     ///
+    /// For example, `jump_ce(1, 64)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 96)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^128 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^128 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u64,
             self,
             [0x095b8f76579aa001, 0x0008828e513b43d5],
             c,
             e,
+            pair
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u64()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u64()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 + … is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^128 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 2]) {
+        impl_jump_n!(
+            u64,
+            self,
+            [0x095b8f76579aa001, 0x0008828e513b43d5],
+            jump,
             pair
         );
     }
@@ -133,42 +154,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u64();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u64();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+        b.jump_ce(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 96);
+        b.jump_ce(1, 96);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,96) == long_jump()"
+            "jump_ce(1,96) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+        }
+        // A distance that needs a high limb: 2^64 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 1]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -56,6 +56,23 @@ impl Xoroshiro128Plus {
     pub fn long_jump(&mut self) {
         impl_jump!(u64, self, [0xd2a98b26625eee7b, 0xdddf9b1090aa7ac1]);
     }
+
+    /// Jump forward by c · 2^e calls to `next_u64()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^128 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u64,
+            self,
+            [0x095b8f76579aa001, 0x0008828e513b43d5],
+            c,
+            e,
+            pair
+        );
+    }
 }
 
 impl TryRng for Xoroshiro128Plus {
@@ -102,6 +119,57 @@ impl SeedableRng for Xoroshiro128Plus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoroshiro128Plus {
+        Xoroshiro128Plus::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoroshiro128Plus) -> [u64; 16] {
+        let mut o = [0; 16];
+        for x in &mut o {
+            *x = rng.next_u64();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u64();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u64();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 96);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,96) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -145,14 +145,6 @@ mod tests {
         Xoroshiro128Plus::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoroshiro128Plus) -> [u64; 16] {
-        let mut o = [0; 16];
-        for x in &mut o {
-            *x = rng.next_u64();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -162,7 +154,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -170,7 +162,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -179,17 +171,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
+        assert_eq!(a, b, "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 96);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,96) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,96) == long_jump()");
     }
 
     #[test]
@@ -200,14 +188,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+            assert_eq!(a, b, "jump_n(&[{d}, …])");
         }
         // A distance that needs a high limb: 2^64 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 1]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+        assert_eq!(a, b, "jump_n(2^64) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -216,7 +204,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoroshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoroshiro128plusplus.rs
@@ -58,17 +58,38 @@ impl Xoroshiro128PlusPlus {
 
     /// Jump forward by c · 2^e calls to `next_u64()`.
     ///
+    /// For example, `jump_ce(1, 64)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 96)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^128 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^128 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u64,
             self,
             [0x8dae70779760b081, 0x0031bcf2f855d6e5],
             c,
             e,
+            pair
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u64()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u64()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 + … is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^128 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 2]) {
+        impl_jump_n!(
+            u64,
+            self,
+            [0x8dae70779760b081, 0x0031bcf2f855d6e5],
+            jump,
             pair
         );
     }
@@ -131,42 +152,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u64();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u64();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+        b.jump_ce(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 96);
+        b.jump_ce(1, 96);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,96) == long_jump()"
+            "jump_ce(1,96) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+        }
+        // A distance that needs a high limb: 2^64 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 1]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoroshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoroshiro128plusplus.rs
@@ -55,6 +55,23 @@ impl Xoroshiro128PlusPlus {
     pub fn long_jump(&mut self) {
         impl_jump!(u64, self, [0x360fd5f2cf8d5d99, 0x9c6e6877736c46e3]);
     }
+
+    /// Jump forward by c · 2^e calls to `next_u64()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^128 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u64,
+            self,
+            [0x8dae70779760b081, 0x0031bcf2f855d6e5],
+            c,
+            e,
+            pair
+        );
+    }
 }
 
 impl TryRng for Xoroshiro128PlusPlus {
@@ -100,6 +117,57 @@ impl SeedableRng for Xoroshiro128PlusPlus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoroshiro128PlusPlus {
+        Xoroshiro128PlusPlus::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoroshiro128PlusPlus) -> [u64; 16] {
+        let mut o = [0; 16];
+        for x in &mut o {
+            *x = rng.next_u64();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u64();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u64();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 96);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,96) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoroshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoroshiro128plusplus.rs
@@ -143,14 +143,6 @@ mod tests {
         Xoroshiro128PlusPlus::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoroshiro128PlusPlus) -> [u64; 16] {
-        let mut o = [0; 16];
-        for x in &mut o {
-            *x = rng.next_u64();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -160,7 +152,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -168,7 +160,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -177,17 +169,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
+        assert_eq!(a, b, "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 96);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,96) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,96) == long_jump()");
     }
 
     #[test]
@@ -198,14 +186,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+            assert_eq!(a, b, "jump_n(&[{d}, …])");
         }
         // A distance that needs a high limb: 2^64 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 1]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+        assert_eq!(a, b, "jump_n(2^64) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -214,7 +202,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -55,6 +55,23 @@ impl Xoroshiro128StarStar {
     pub fn long_jump(&mut self) {
         impl_jump!(u64, self, [0xd2a98b26625eee7b, 0xdddf9b1090aa7ac1]);
     }
+
+    /// Jump forward by c · 2^e calls to `next_u64()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^128 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u64,
+            self,
+            [0x095b8f76579aa001, 0x0008828e513b43d5],
+            c,
+            e,
+            pair
+        );
+    }
 }
 
 impl TryRng for Xoroshiro128StarStar {
@@ -100,6 +117,57 @@ impl SeedableRng for Xoroshiro128StarStar {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoroshiro128StarStar {
+        Xoroshiro128StarStar::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoroshiro128StarStar) -> [u64; 16] {
+        let mut o = [0; 16];
+        for x in &mut o {
+            *x = rng.next_u64();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u64();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u64();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 96);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,96) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -58,17 +58,38 @@ impl Xoroshiro128StarStar {
 
     /// Jump forward by c · 2^e calls to `next_u64()`.
     ///
+    /// For example, `jump_ce(1, 64)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 96)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^128 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^128 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u64,
             self,
             [0x095b8f76579aa001, 0x0008828e513b43d5],
             c,
             e,
+            pair
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u64()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u64()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 + … is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^128 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 2]) {
+        impl_jump_n!(
+            u64,
+            self,
+            [0x095b8f76579aa001, 0x0008828e513b43d5],
+            jump,
             pair
         );
     }
@@ -131,42 +152,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u64();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u64();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+        b.jump_ce(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 96);
+        b.jump_ce(1, 96);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,96) == long_jump()"
+            "jump_ce(1,96) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+        }
+        // A distance that needs a high limb: 2^64 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 1]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -143,14 +143,6 @@ mod tests {
         Xoroshiro128StarStar::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoroshiro128StarStar) -> [u64; 16] {
-        let mut o = [0; 16];
-        for x in &mut o {
-            *x = rng.next_u64();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -160,7 +152,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -168,7 +160,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -177,17 +169,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
+        assert_eq!(a, b, "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 96);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,96) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,96) == long_jump()");
     }
 
     #[test]
@@ -198,14 +186,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+            assert_eq!(a, b, "jump_n(&[{d}, …])");
         }
         // A distance that needs a high limb: 2^64 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 1]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+        assert_eq!(a, b, "jump_n(2^64) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -214,7 +202,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -57,17 +57,38 @@ impl Xoshiro128Plus {
 
     /// Jump forward by c · 2^e calls to `next_u32()`.
     ///
+    /// For example, `jump_ce(1, 64)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 96)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^128 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^128 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u32,
             self,
             [0x1b489db6de18fc01, 0x00fc65a2006254b1],
             c,
             e,
+            array4
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u32()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u32()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^128 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 2]) {
+        impl_jump_n!(
+            u32,
+            self,
+            [0x1b489db6de18fc01, 0x00fc65a2006254b1],
+            jump,
             array4
         );
     }
@@ -131,42 +152,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u32();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u32();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+        b.jump_ce(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 96);
+        b.jump_ce(1, 96);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,96) == long_jump()"
+            "jump_ce(1,96) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, 0])");
+        }
+        // A distance that needs a high limb: 2^64 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 1]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -143,14 +143,6 @@ mod tests {
         Xoshiro128Plus::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoshiro128Plus) -> [u32; 16] {
-        let mut o = [0u32; 16];
-        for x in &mut o {
-            *x = rng.next_u32();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -160,7 +152,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -168,7 +160,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -177,17 +169,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
+        assert_eq!(a, b, "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 96);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,96) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,96) == long_jump()");
     }
 
     #[test]
@@ -198,14 +186,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, 0])");
+            assert_eq!(a, b, "jump_n(&[{d}, 0])");
         }
         // A distance that needs a high limb: 2^64 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 1]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+        assert_eq!(a, b, "jump_n(2^64) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -214,7 +202,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -54,6 +54,23 @@ impl Xoshiro128Plus {
     pub fn long_jump(&mut self) {
         impl_jump!(u32, self, [0xb523952e, 0x0b6f099f, 0xccf5a0ef, 0x1c580662]);
     }
+
+    /// Jump forward by c · 2^e calls to `next_u32()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^128 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u32,
+            self,
+            [0x1b489db6de18fc01, 0x00fc65a2006254b1],
+            c,
+            e,
+            array4
+        );
+    }
 }
 
 impl_state_array_of_four!(Xoshiro128Plus, u32);
@@ -100,6 +117,57 @@ impl TryRng for Xoshiro128Plus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoshiro128Plus {
+        Xoshiro128Plus::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoshiro128Plus) -> [u32; 16] {
+        let mut o = [0u32; 16];
+        for x in &mut o {
+            *x = rng.next_u32();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u32();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u32();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 96);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,96) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoshiro128plusplus.rs
@@ -56,17 +56,38 @@ impl Xoshiro128PlusPlus {
 
     /// Jump forward by c · 2^e calls to `next_u32()`.
     ///
+    /// For example, `jump_ce(1, 64)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 96)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^128 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^128 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u32,
             self,
             [0x1b489db6de18fc01, 0x00fc65a2006254b1],
             c,
             e,
+            array4
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u32()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u32()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^128 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 2]) {
+        impl_jump_n!(
+            u32,
+            self,
+            [0x1b489db6de18fc01, 0x00fc65a2006254b1],
+            jump,
             array4
         );
     }
@@ -130,42 +151,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u32();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u32();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+        b.jump_ce(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 96);
+        b.jump_ce(1, 96);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,96) == long_jump()"
+            "jump_ce(1,96) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, 0])");
+        }
+        // A distance that needs a high limb: 2^64 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 1]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoshiro128plusplus.rs
@@ -142,14 +142,6 @@ mod tests {
         Xoshiro128PlusPlus::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoshiro128PlusPlus) -> [u32; 16] {
-        let mut o = [0u32; 16];
-        for x in &mut o {
-            *x = rng.next_u32();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -159,7 +151,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -167,7 +159,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -176,17 +168,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
+        assert_eq!(a, b, "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 96);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,96) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,96) == long_jump()");
     }
 
     #[test]
@@ -197,14 +185,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, 0])");
+            assert_eq!(a, b, "jump_n(&[{d}, 0])");
         }
         // A distance that needs a high limb: 2^64 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 1]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+        assert_eq!(a, b, "jump_n(2^64) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -213,7 +201,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoshiro128plusplus.rs
@@ -53,6 +53,23 @@ impl Xoshiro128PlusPlus {
     pub fn long_jump(&mut self) {
         impl_jump!(u32, self, [0xb523952e, 0x0b6f099f, 0xccf5a0ef, 0x1c580662]);
     }
+
+    /// Jump forward by c · 2^e calls to `next_u32()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^128 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u32,
+            self,
+            [0x1b489db6de18fc01, 0x00fc65a2006254b1],
+            c,
+            e,
+            array4
+        );
+    }
 }
 
 impl_state_array_of_four!(Xoshiro128PlusPlus, u32);
@@ -99,6 +116,57 @@ impl TryRng for Xoshiro128PlusPlus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoshiro128PlusPlus {
+        Xoshiro128PlusPlus::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoshiro128PlusPlus) -> [u32; 16] {
+        let mut o = [0u32; 16];
+        for x in &mut o {
+            *x = rng.next_u32();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u32();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u32();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 96);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,96) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -142,14 +142,6 @@ mod tests {
         Xoshiro128StarStar::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoshiro128StarStar) -> [u32; 16] {
-        let mut o = [0u32; 16];
-        for x in &mut o {
-            *x = rng.next_u32();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -159,7 +151,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -167,7 +159,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -176,17 +168,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
+        assert_eq!(a, b, "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 96);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,96) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,96) == long_jump()");
     }
 
     #[test]
@@ -197,14 +185,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, 0])");
+            assert_eq!(a, b, "jump_n(&[{d}, 0])");
         }
         // A distance that needs a high limb: 2^64 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 1]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+        assert_eq!(a, b, "jump_n(2^64) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -213,7 +201,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -56,17 +56,38 @@ impl Xoshiro128StarStar {
 
     /// Jump forward by c · 2^e calls to `next_u32()`.
     ///
+    /// For example, `jump_ce(1, 64)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 96)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^128 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^128 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u32,
             self,
             [0x1b489db6de18fc01, 0x00fc65a2006254b1],
             c,
             e,
+            array4
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u32()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u32()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^128 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 2]) {
+        impl_jump_n!(
+            u32,
+            self,
+            [0x1b489db6de18fc01, 0x00fc65a2006254b1],
+            jump,
             array4
         );
     }
@@ -130,42 +151,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u32();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u32();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 64);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+        b.jump_ce(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,64) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 96);
+        b.jump_ce(1, 96);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,96) == long_jump()"
+            "jump_ce(1,96) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, 0])");
+        }
+        // A distance that needs a high limb: 2^64 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 1]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^64) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -53,6 +53,23 @@ impl Xoshiro128StarStar {
     pub fn long_jump(&mut self) {
         impl_jump!(u32, self, [0xb523952e, 0x0b6f099f, 0xccf5a0ef, 0x1c580662]);
     }
+
+    /// Jump forward by c · 2^e calls to `next_u32()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^128 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u32,
+            self,
+            [0x1b489db6de18fc01, 0x00fc65a2006254b1],
+            c,
+            e,
+            array4
+        );
+    }
 }
 
 impl_state_array_of_four!(Xoshiro128StarStar, u32);
@@ -99,6 +116,57 @@ impl TryRng for Xoshiro128StarStar {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoshiro128StarStar {
+        Xoshiro128StarStar::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoshiro128StarStar) -> [u32; 16] {
+        let mut o = [0u32; 16];
+        for x in &mut o {
+            *x = rng.next_u32();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u32();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u32();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 64);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,64) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 96);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,96) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -173,14 +173,6 @@ mod tests {
         Xoshiro256Plus::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoshiro256Plus) -> [u64; 16] {
-        let mut o = [0; 16];
-        for x in &mut o {
-            *x = rng.next_u64();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -190,7 +182,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -198,7 +190,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -207,17 +199,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 128);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,128) == jump()");
+        assert_eq!(a, b, "jump_ce(1,128) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 192);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,192) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,192) == long_jump()");
     }
 
     #[test]
@@ -228,14 +216,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0, 0, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+            assert_eq!(a, b, "jump_n(&[{d}, …])");
         }
         // A distance that needs a high limb: 2^128 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 0, 1, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^128) == jump()");
+        assert_eq!(a, b, "jump_n(2^128) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -244,7 +232,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5, 0, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -75,12 +75,16 @@ impl Xoshiro256Plus {
 
     /// Jump forward by c · 2^e calls to `next_u64()`.
     ///
+    /// For example, `jump_ce(1, 128)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 192)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^256 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^256 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u64,
             self,
             [
@@ -91,6 +95,28 @@ impl Xoshiro256Plus {
             ],
             c,
             e,
+            array4
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u64()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u64()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 + … is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^256 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 4]) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0x9d116f2bb0f0f001,
+                0x0280002bcefd1a5e,
+                0x04b4edcf26259f85,
+                0x0003c03c3f3ecb19
+            ],
+            jump,
             array4
         );
     }
@@ -156,42 +182,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u64();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u64();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 128);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,128) == jump()");
+        b.jump_ce(1, 128);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,128) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 192);
+        b.jump_ce(1, 192);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,192) == long_jump()"
+            "jump_ce(1,192) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0, 0, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+        }
+        // A distance that needs a high limb: 2^128 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 0, 1, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^128) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5, 0, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -72,6 +72,28 @@ impl Xoshiro256Plus {
             ]
         );
     }
+
+    /// Jump forward by c · 2^e calls to `next_u64()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^256 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0x9d116f2bb0f0f001,
+                0x0280002bcefd1a5e,
+                0x04b4edcf26259f85,
+                0x0003c03c3f3ecb19
+            ],
+            c,
+            e,
+            array4
+        );
+    }
 }
 
 impl_state_array_of_four!(Xoshiro256Plus, u64);
@@ -120,6 +142,57 @@ impl TryRng for Xoshiro256Plus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoshiro256Plus {
+        Xoshiro256Plus::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoshiro256Plus) -> [u64; 16] {
+        let mut o = [0; 16];
+        for x in &mut o {
+            *x = rng.next_u64();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u64();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u64();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 128);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,128) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 192);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,192) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -173,14 +173,6 @@ mod tests {
         0, 0,
     ];
 
-    fn outputs(rng: &mut Xoshiro256PlusPlus) -> [u64; 16] {
-        let mut o = [0; 16];
-        for x in &mut o {
-            *x = rng.next_u64();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -190,7 +182,7 @@ mod tests {
             }
             let mut b = Xoshiro256PlusPlus::from_seed(SEED);
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         // c * 2^e with e > 0, small enough to step literally: 3 * 2^8 = 768.
         let mut a = Xoshiro256PlusPlus::from_seed(SEED);
@@ -199,7 +191,7 @@ mod tests {
         }
         let mut b = Xoshiro256PlusPlus::from_seed(SEED);
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -208,17 +200,13 @@ mod tests {
         a.jump();
         let mut b = Xoshiro256PlusPlus::from_seed(SEED);
         b.jump_ce(1, 128);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,128) == jump()");
+        assert_eq!(a, b, "jump_ce(1,128) == jump()");
 
         let mut a = Xoshiro256PlusPlus::from_seed(SEED);
         a.long_jump();
         let mut b = Xoshiro256PlusPlus::from_seed(SEED);
         b.jump_ce(1, 192);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,192) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,192) == long_jump()");
     }
 
     #[test]
@@ -229,14 +217,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = Xoshiro256PlusPlus::from_seed(SEED);
             b.jump_n(&[d, 0, 0, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+            assert_eq!(a, b, "jump_n(&[{d}, …])");
         }
         // A distance that needs a high limb: 2^128 == jump().
         let mut a = Xoshiro256PlusPlus::from_seed(SEED);
         a.jump();
         let mut b = Xoshiro256PlusPlus::from_seed(SEED);
         b.jump_n(&[0, 0, 1, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^128) == jump()");
+        assert_eq!(a, b, "jump_n(2^128) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -245,7 +233,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = Xoshiro256PlusPlus::from_seed(SEED);
         b.jump_n(&[3, 5, 0, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -71,6 +71,28 @@ impl Xoshiro256PlusPlus {
             ]
         );
     }
+
+    /// Jump forward by c · 2^e calls to `next_u64()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^256 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0x9d116f2bb0f0f001,
+                0x0280002bcefd1a5e,
+                0x04b4edcf26259f85,
+                0x0003c03c3f3ecb19
+            ],
+            c,
+            e,
+            array4
+        );
+    }
 }
 
 impl_state_array_of_four!(Xoshiro256PlusPlus, u64);
@@ -119,6 +141,59 @@ impl TryRng for Xoshiro256PlusPlus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const SEED: [u8; 32] = [
+        1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0,
+        0, 0,
+    ];
+
+    fn outputs(rng: &mut Xoshiro256PlusPlus) -> [u64; 16] {
+        let mut o = [0; 16];
+        for x in &mut o {
+            *x = rng.next_u64();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = Xoshiro256PlusPlus::from_seed(SEED);
+            for _ in 0..d {
+                a.next_u64();
+            }
+            let mut b = Xoshiro256PlusPlus::from_seed(SEED);
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        // c * 2^e with e > 0, small enough to step literally: 3 * 2^8 = 768.
+        let mut a = Xoshiro256PlusPlus::from_seed(SEED);
+        for _ in 0..3 * 256 {
+            a.next_u64();
+        }
+        let mut b = Xoshiro256PlusPlus::from_seed(SEED);
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = Xoshiro256PlusPlus::from_seed(SEED);
+        a.jump();
+        let mut b = Xoshiro256PlusPlus::from_seed(SEED);
+        b.jump_n(1, 128);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,128) == jump()");
+
+        let mut a = Xoshiro256PlusPlus::from_seed(SEED);
+        a.long_jump();
+        let mut b = Xoshiro256PlusPlus::from_seed(SEED);
+        b.jump_n(1, 192);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,192) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -74,12 +74,16 @@ impl Xoshiro256PlusPlus {
 
     /// Jump forward by c · 2^e calls to `next_u64()`.
     ///
+    /// For example, `jump_ce(1, 128)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 192)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^256 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^256 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u64,
             self,
             [
@@ -90,6 +94,28 @@ impl Xoshiro256PlusPlus {
             ],
             c,
             e,
+            array4
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u64()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u64()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 + … is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^256 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 4]) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0x9d116f2bb0f0f001,
+                0x0280002bcefd1a5e,
+                0x04b4edcf26259f85,
+                0x0003c03c3f3ecb19
+            ],
+            jump,
             array4
         );
     }
@@ -156,15 +182,15 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = Xoshiro256PlusPlus::from_seed(SEED);
             for _ in 0..d {
                 a.next_u64();
             }
             let mut b = Xoshiro256PlusPlus::from_seed(SEED);
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         // c * 2^e with e > 0, small enough to step literally: 3 * 2^8 = 768.
         let mut a = Xoshiro256PlusPlus::from_seed(SEED);
@@ -172,27 +198,54 @@ mod tests {
             a.next_u64();
         }
         let mut b = Xoshiro256PlusPlus::from_seed(SEED);
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = Xoshiro256PlusPlus::from_seed(SEED);
         a.jump();
         let mut b = Xoshiro256PlusPlus::from_seed(SEED);
-        b.jump_n(1, 128);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,128) == jump()");
+        b.jump_ce(1, 128);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,128) == jump()");
 
         let mut a = Xoshiro256PlusPlus::from_seed(SEED);
         a.long_jump();
         let mut b = Xoshiro256PlusPlus::from_seed(SEED);
-        b.jump_n(1, 192);
+        b.jump_ce(1, 192);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,192) == long_jump()"
+            "jump_ce(1,192) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = Xoshiro256PlusPlus::from_seed(SEED);
+            a.jump_ce(d, 0);
+            let mut b = Xoshiro256PlusPlus::from_seed(SEED);
+            b.jump_n(&[d, 0, 0, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+        }
+        // A distance that needs a high limb: 2^128 == jump().
+        let mut a = Xoshiro256PlusPlus::from_seed(SEED);
+        a.jump();
+        let mut b = Xoshiro256PlusPlus::from_seed(SEED);
+        b.jump_n(&[0, 0, 1, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^128) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = Xoshiro256PlusPlus::from_seed(SEED);
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = Xoshiro256PlusPlus::from_seed(SEED);
+        b.jump_n(&[3, 5, 0, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -71,6 +71,28 @@ impl Xoshiro256StarStar {
             ]
         );
     }
+
+    /// Jump forward by c · 2^e calls to `next_u64()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^256 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0x9d116f2bb0f0f001,
+                0x0280002bcefd1a5e,
+                0x04b4edcf26259f85,
+                0x0003c03c3f3ecb19
+            ],
+            c,
+            e,
+            array4
+        );
+    }
 }
 
 impl_state_array_of_four!(Xoshiro256StarStar, u64);
@@ -119,6 +141,57 @@ impl TryRng for Xoshiro256StarStar {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoshiro256StarStar {
+        Xoshiro256StarStar::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoshiro256StarStar) -> [u64; 16] {
+        let mut o = [0; 16];
+        for x in &mut o {
+            *x = rng.next_u64();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u64();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u64();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 128);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,128) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 192);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,192) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -74,12 +74,16 @@ impl Xoshiro256StarStar {
 
     /// Jump forward by c · 2^e calls to `next_u64()`.
     ///
+    /// For example, `jump_ce(1, 128)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 192)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^256 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^256 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u64,
             self,
             [
@@ -90,6 +94,28 @@ impl Xoshiro256StarStar {
             ],
             c,
             e,
+            array4
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u64()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u64()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 + … is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^256 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 4]) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0x9d116f2bb0f0f001,
+                0x0280002bcefd1a5e,
+                0x04b4edcf26259f85,
+                0x0003c03c3f3ecb19
+            ],
+            jump,
             array4
         );
     }
@@ -155,42 +181,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u64();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u64();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 128);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,128) == jump()");
+        b.jump_ce(1, 128);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,128) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 192);
+        b.jump_ce(1, 192);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,192) == long_jump()"
+            "jump_ce(1,192) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0, 0, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+        }
+        // A distance that needs a high limb: 2^128 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 0, 1, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^128) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5, 0, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -172,14 +172,6 @@ mod tests {
         Xoshiro256StarStar::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoshiro256StarStar) -> [u64; 16] {
-        let mut o = [0; 16];
-        for x in &mut o {
-            *x = rng.next_u64();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -189,7 +181,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -197,7 +189,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -206,17 +198,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 128);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,128) == jump()");
+        assert_eq!(a, b, "jump_ce(1,128) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 192);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,192) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,192) == long_jump()");
     }
 
     #[test]
@@ -227,14 +215,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0, 0, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+            assert_eq!(a, b, "jump_n(&[{d}, …])");
         }
         // A distance that needs a high limb: 2^128 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 0, 1, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^128) == jump()");
+        assert_eq!(a, b, "jump_n(2^128) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -243,7 +231,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5, 0, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -191,14 +191,6 @@ mod tests {
         Xoshiro512Plus::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoshiro512Plus) -> [u64; 16] {
-        let mut o = [0; 16];
-        for x in &mut o {
-            *x = rng.next_u64();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -208,7 +200,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -216,7 +208,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -225,17 +217,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 256);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,256) == jump()");
+        assert_eq!(a, b, "jump_ce(1,256) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 384);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,384) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,384) == long_jump()");
     }
 
     #[test]
@@ -246,14 +234,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0, 0, 0, 0, 0, 0, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+            assert_eq!(a, b, "jump_n(&[{d}, …])");
         }
         // A distance that needs a high limb: 2^256 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 0, 0, 0, 1, 0, 0, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^256) == jump()");
+        assert_eq!(a, b, "jump_n(2^256) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -262,7 +250,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -82,6 +82,32 @@ impl Xoshiro512Plus {
             ]
         );
     }
+
+    /// Jump forward by c · 2^e calls to `next_u64()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^512 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0xcf3cff0c00000001,
+                0x7fdc78d886f00c63,
+                0xf05e63fca6d7b781,
+                0x7a67058e7bbab6f0,
+                0xf11eef832e32518f,
+                0x51ba7c47edc758ad,
+                0x8f2d27268ce4b20b,
+                0x0000500055d8b77f
+            ],
+            c,
+            e,
+            array8
+        );
+    }
 }
 
 impl_state_seed512!(Xoshiro512Plus);
@@ -130,6 +156,57 @@ impl TryRng for Xoshiro512Plus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoshiro512Plus {
+        Xoshiro512Plus::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoshiro512Plus) -> [u64; 16] {
+        let mut o = [0; 16];
+        for x in &mut o {
+            *x = rng.next_u64();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u64();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u64();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 256);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,256) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 384);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,384) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -85,12 +85,16 @@ impl Xoshiro512Plus {
 
     /// Jump forward by c · 2^e calls to `next_u64()`.
     ///
+    /// For example, `jump_ce(1, 256)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 384)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^512 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^512 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u64,
             self,
             [
@@ -105,6 +109,32 @@ impl Xoshiro512Plus {
             ],
             c,
             e,
+            array8
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u64()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u64()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 + … is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^512 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 8]) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0xcf3cff0c00000001,
+                0x7fdc78d886f00c63,
+                0xf05e63fca6d7b781,
+                0x7a67058e7bbab6f0,
+                0xf11eef832e32518f,
+                0x51ba7c47edc758ad,
+                0x8f2d27268ce4b20b,
+                0x0000500055d8b77f
+            ],
+            jump,
             array8
         );
     }
@@ -170,42 +200,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u64();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u64();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 256);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,256) == jump()");
+        b.jump_ce(1, 256);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,256) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 384);
+        b.jump_ce(1, 384);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,384) == long_jump()"
+            "jump_ce(1,384) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0, 0, 0, 0, 0, 0, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+        }
+        // A distance that needs a high limb: 2^256 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 0, 0, 0, 1, 0, 0, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^256) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -190,14 +190,6 @@ mod tests {
         Xoshiro512PlusPlus::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoshiro512PlusPlus) -> [u64; 16] {
-        let mut o = [0; 16];
-        for x in &mut o {
-            *x = rng.next_u64();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -207,7 +199,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -215,7 +207,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -224,17 +216,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 256);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,256) == jump()");
+        assert_eq!(a, b, "jump_ce(1,256) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 384);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,384) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,384) == long_jump()");
     }
 
     #[test]
@@ -245,14 +233,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0, 0, 0, 0, 0, 0, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+            assert_eq!(a, b, "jump_n(&[{d}, …])");
         }
         // A distance that needs a high limb: 2^256 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 0, 0, 0, 1, 0, 0, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^256) == jump()");
+        assert_eq!(a, b, "jump_n(2^256) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -261,7 +249,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -81,6 +81,32 @@ impl Xoshiro512PlusPlus {
             ]
         );
     }
+
+    /// Jump forward by c · 2^e calls to `next_u64()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^512 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0xcf3cff0c00000001,
+                0x7fdc78d886f00c63,
+                0xf05e63fca6d7b781,
+                0x7a67058e7bbab6f0,
+                0xf11eef832e32518f,
+                0x51ba7c47edc758ad,
+                0x8f2d27268ce4b20b,
+                0x0000500055d8b77f
+            ],
+            c,
+            e,
+            array8
+        );
+    }
 }
 
 impl_state_seed512!(Xoshiro512PlusPlus);
@@ -129,6 +155,57 @@ impl TryRng for Xoshiro512PlusPlus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoshiro512PlusPlus {
+        Xoshiro512PlusPlus::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoshiro512PlusPlus) -> [u64; 16] {
+        let mut o = [0; 16];
+        for x in &mut o {
+            *x = rng.next_u64();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u64();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u64();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 256);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,256) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 384);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,384) == long_jump()"
+        );
+    }
 
     #[test]
     fn reference() {

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -84,12 +84,16 @@ impl Xoshiro512PlusPlus {
 
     /// Jump forward by c · 2^e calls to `next_u64()`.
     ///
+    /// For example, `jump_ce(1, 256)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 384)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^512 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^512 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u64,
             self,
             [
@@ -104,6 +108,32 @@ impl Xoshiro512PlusPlus {
             ],
             c,
             e,
+            array8
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u64()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u64()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 + … is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^512 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 8]) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0xcf3cff0c00000001,
+                0x7fdc78d886f00c63,
+                0xf05e63fca6d7b781,
+                0x7a67058e7bbab6f0,
+                0xf11eef832e32518f,
+                0x51ba7c47edc758ad,
+                0x8f2d27268ce4b20b,
+                0x0000500055d8b77f
+            ],
+            jump,
             array8
         );
     }
@@ -169,42 +199,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u64();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u64();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 256);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,256) == jump()");
+        b.jump_ce(1, 256);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,256) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 384);
+        b.jump_ce(1, 384);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,384) == long_jump()"
+            "jump_ce(1,384) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0, 0, 0, 0, 0, 0, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+        }
+        // A distance that needs a high limb: 2^256 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 0, 0, 0, 1, 0, 0, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^256) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -190,14 +190,6 @@ mod tests {
         Xoshiro512StarStar::seed_from_u64(0x0123456789abcdef)
     }
 
-    fn outputs(rng: &mut Xoshiro512StarStar) -> [u64; 16] {
-        let mut o = [0; 16];
-        for x in &mut o {
-            *x = rng.next_u64();
-        }
-        o
-    }
-
     #[test]
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
@@ -207,7 +199,7 @@ mod tests {
             }
             let mut b = fresh();
             b.jump_ce(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
+            assert_eq!(a, b, "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
@@ -215,7 +207,7 @@ mod tests {
         }
         let mut b = fresh();
         b.jump_ce(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
+        assert_eq!(a, b, "jump_ce(3, 8)");
     }
 
     #[test]
@@ -224,17 +216,13 @@ mod tests {
         a.jump();
         let mut b = fresh();
         b.jump_ce(1, 256);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,256) == jump()");
+        assert_eq!(a, b, "jump_ce(1,256) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
         b.jump_ce(1, 384);
-        assert_eq!(
-            outputs(&mut a),
-            outputs(&mut b),
-            "jump_ce(1,384) == long_jump()"
-        );
+        assert_eq!(a, b, "jump_ce(1,384) == long_jump()");
     }
 
     #[test]
@@ -245,14 +233,14 @@ mod tests {
             a.jump_ce(d, 0);
             let mut b = fresh();
             b.jump_n(&[d, 0, 0, 0, 0, 0, 0, 0]);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+            assert_eq!(a, b, "jump_n(&[{d}, …])");
         }
         // A distance that needs a high limb: 2^256 == jump().
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
         b.jump_n(&[0, 0, 0, 0, 1, 0, 0, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^256) == jump()");
+        assert_eq!(a, b, "jump_n(2^256) == jump()");
 
         // A distance jump_ce cannot express (odd part exceeds 64 bits):
         // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
@@ -261,7 +249,7 @@ mod tests {
         a.jump_ce(5, 64);
         let mut b = fresh();
         b.jump_n(&[3, 5, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
+        assert_eq!(a, b, "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -84,12 +84,16 @@ impl Xoshiro512StarStar {
 
     /// Jump forward by c · 2^e calls to `next_u64()`.
     ///
+    /// For example, `jump_ce(1, 256)` is equivalent to [`jump`](Self::jump)
+    /// and `jump_ce(1, 384)` is equivalent to [`long_jump`](Self::long_jump).
     /// Expressing the distance as c · 2^e makes it possible to request both
-    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// ordinary counts (`jump_ce(k, 0)`) and very large power-of-two jumps
     /// without multiple-precision integers. For the jump to be meaningful,
-    /// c · 2^e should be smaller than the period 2^512 - 1.
-    pub fn jump_n(&mut self, c: u64, e: u64) {
-        impl_jump_n!(
+    /// c · 2^e should be smaller than the period 2^512 − 1.
+    ///
+    /// See [`jump_n`](Self::jump_n) to jump by an arbitrary distance.
+    pub fn jump_ce(&mut self, c: u64, e: u32) {
+        impl_jump_ce!(
             u64,
             self,
             [
@@ -104,6 +108,32 @@ impl Xoshiro512StarStar {
             ],
             c,
             e,
+            array8
+        );
+    }
+
+    /// Jump forward by an arbitrary number of calls to `next_u64()`.
+    ///
+    /// This is equivalent to *n* calls to `next_u64()`, where *n* = `jump[0]` +
+    /// `jump[1]` · 2^64 + … is the little-endian integer held in `jump`.
+    /// Unlike [`jump_ce`](Self::jump_ce), it can express any jump distance.
+    /// For the jump to be meaningful, *n* should be smaller than the period
+    /// 2^512 − 1.
+    pub fn jump_n(&mut self, jump: &[u64; 8]) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0xcf3cff0c00000001,
+                0x7fdc78d886f00c63,
+                0xf05e63fca6d7b781,
+                0x7a67058e7bbab6f0,
+                0xf11eef832e32518f,
+                0x51ba7c47edc758ad,
+                0x8f2d27268ce4b20b,
+                0x0000500055d8b77f
+            ],
+            jump,
             array8
         );
     }
@@ -169,42 +199,69 @@ mod tests {
     }
 
     #[test]
-    fn jump_n_small_distances_match_stepping() {
+    fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
             for _ in 0..d {
                 a.next_u64();
             }
             let mut b = fresh();
-            b.jump_n(d, 0);
-            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+            b.jump_ce(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce({d}, 0)");
         }
         let mut a = fresh();
         for _ in 0..3 * 256 {
             a.next_u64();
         }
         let mut b = fresh();
-        b.jump_n(3, 8);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+        b.jump_ce(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(3, 8)");
     }
 
     #[test]
-    fn jump_n_matches_predefined_jumps() {
+    fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
         let mut b = fresh();
-        b.jump_n(1, 256);
-        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,256) == jump()");
+        b.jump_ce(1, 256);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_ce(1,256) == jump()");
 
         let mut a = fresh();
         a.long_jump();
         let mut b = fresh();
-        b.jump_n(1, 384);
+        b.jump_ce(1, 384);
         assert_eq!(
             outputs(&mut a),
             outputs(&mut b),
-            "jump_n(1,384) == long_jump()"
+            "jump_ce(1,384) == long_jump()"
         );
+    }
+
+    #[test]
+    fn jump_n_matches_jump_ce() {
+        // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            a.jump_ce(d, 0);
+            let mut b = fresh();
+            b.jump_n(&[d, 0, 0, 0, 0, 0, 0, 0]);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(&[{d}, …])");
+        }
+        // A distance that needs a high limb: 2^256 == jump().
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(&[0, 0, 0, 0, 1, 0, 0, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(2^256) == jump()");
+
+        // A distance jump_ce cannot express (odd part exceeds 64 bits):
+        // 3 + 5 · 2^64, checked via x^(a + b) = x^a · x^b.
+        let mut a = fresh();
+        a.jump_ce(3, 0);
+        a.jump_ce(5, 64);
+        let mut b = fresh();
+        b.jump_n(&[3, 5, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3 + 5 · 2^64)");
     }
 
     #[test]

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -81,6 +81,32 @@ impl Xoshiro512StarStar {
             ]
         );
     }
+
+    /// Jump forward by c · 2^e calls to `next_u64()`.
+    ///
+    /// Expressing the distance as c · 2^e makes it possible to request both
+    /// ordinary counts (`jump_n(k, 0)`) and very large power-of-two jumps
+    /// without multiple-precision integers. For the jump to be meaningful,
+    /// c · 2^e should be smaller than the period 2^512 - 1.
+    pub fn jump_n(&mut self, c: u64, e: u64) {
+        impl_jump_n!(
+            u64,
+            self,
+            [
+                0xcf3cff0c00000001,
+                0x7fdc78d886f00c63,
+                0xf05e63fca6d7b781,
+                0x7a67058e7bbab6f0,
+                0xf11eef832e32518f,
+                0x51ba7c47edc758ad,
+                0x8f2d27268ce4b20b,
+                0x0000500055d8b77f
+            ],
+            c,
+            e,
+            array8
+        );
+    }
 }
 
 impl_state_seed512!(Xoshiro512StarStar);
@@ -129,6 +155,57 @@ impl TryRng for Xoshiro512StarStar {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fresh() -> Xoshiro512StarStar {
+        Xoshiro512StarStar::seed_from_u64(0x0123456789abcdef)
+    }
+
+    fn outputs(rng: &mut Xoshiro512StarStar) -> [u64; 16] {
+        let mut o = [0; 16];
+        for x in &mut o {
+            *x = rng.next_u64();
+        }
+        o
+    }
+
+    #[test]
+    fn jump_n_small_distances_match_stepping() {
+        for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
+            let mut a = fresh();
+            for _ in 0..d {
+                a.next_u64();
+            }
+            let mut b = fresh();
+            b.jump_n(d, 0);
+            assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n({d}, 0)");
+        }
+        let mut a = fresh();
+        for _ in 0..3 * 256 {
+            a.next_u64();
+        }
+        let mut b = fresh();
+        b.jump_n(3, 8);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(3, 8)");
+    }
+
+    #[test]
+    fn jump_n_matches_predefined_jumps() {
+        let mut a = fresh();
+        a.jump();
+        let mut b = fresh();
+        b.jump_n(1, 256);
+        assert_eq!(outputs(&mut a), outputs(&mut b), "jump_n(1,256) == jump()");
+
+        let mut a = fresh();
+        a.long_jump();
+        let mut b = fresh();
+        b.jump_n(1, 384);
+        assert_eq!(
+            outputs(&mut a),
+            outputs(&mut b),
+            "jump_n(1,384) == long_jump()"
+        );
+    }
 
     #[test]
     #[rustfmt::skip]


### PR DESCRIPTION
I have recently [published C code for arbitrary jumps](https://prng.di.unimi.it/) for these generators. The stimulus was a user complaining for the lack of arbitrary jumps, as the code was very simple. I disagreed initially, but then I realized that, yes, in fact, the code is really simple. 

So since the crate already has fixed jumps, I thought it would have been a good idea to have arbitrary jumps, too.
There is a minimal `f2x.rs` library for polynomials over **F**₂[_x_] that is used to compute a power of *x* modulo the characteristic polynomial. I tried also a version using the `gf2` crate, but it's just twice as fast, and timings in the worst case are in the order of milliseconds.

I tried to follow as strictly as possible the style of the crate. There's a comment in the change log, but I didn't bump the release number.

The original jumps are still useful as they're constant-time. There is now a `jump_ce` that is what mostly users need (coefficient + esponent, e.g., for starting multiple generators at distances that are large powers of 2), and a `jump_n` that provides arbitrary jumps but needs the jump to be passed as a multipreicision array.

`xoroshiro64`-based generators do not have jumps at all, so I didn't add arbitrary jumps either.