### PR TITLE
Skip slow miri tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+# Configuration for cargo-nextest. See https://nexte.st/docs/configuration/
+#
+# Note: nextest does not run doctests. Run `cargo test --doc` separately.
+
+[profile.default]
+fail-fast = false
+slow-timeout = { period = "10s", terminate-after = 6 }
+final-status-level = "slow"

--- a/rand_xoshiro/src/f2x.rs
+++ b/rand_xoshiro/src/f2x.rs
@@ -124,6 +124,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_poly_ce_matches_repeated_mul_x_for_e0() {
         for &c in &[0, 1, 2, 3, 7, 64, 1000, 5000] {
             let mut out = [0; 4];
@@ -133,6 +134,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_poly_ce_matches_repeated_mul_x_for_powers_of_two() {
         // jump_poly_ce(1, e) == x^(2^e); compare to 2^e applications of mul_x.
         for e in 0..=12 {
@@ -173,6 +175,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_poly_n_matches_ce_single_word() {
         // jump_poly_n(&[n]) == jump_poly_ce(n, 0) for a single-word distance.
         for &n in &[0, 1, 2, 3, 7, 64, 1000, 5000] {
@@ -185,6 +188,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_poly_n_matches_ce_multi_word() {
         // n = c * 2^64 is the two-word integer [0, c]; compare to ce(c, 64).
         for &c in &[1, 3, 5000] {

--- a/rand_xoshiro/src/xoroshiro128plus.rs
+++ b/rand_xoshiro/src/xoroshiro128plus.rs
@@ -146,6 +146,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -181,6 +182,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoroshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoroshiro128plusplus.rs
@@ -144,6 +144,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -179,6 +180,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoroshiro128starstar.rs
+++ b/rand_xoshiro/src/xoroshiro128starstar.rs
@@ -144,6 +144,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -179,6 +180,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoshiro128plus.rs
+++ b/rand_xoshiro/src/xoshiro128plus.rs
@@ -144,6 +144,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -179,6 +180,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoshiro128plusplus.rs
+++ b/rand_xoshiro/src/xoshiro128plusplus.rs
@@ -143,6 +143,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -178,6 +179,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoshiro128starstar.rs
+++ b/rand_xoshiro/src/xoshiro128starstar.rs
@@ -143,6 +143,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -178,6 +179,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoshiro256plus.rs
+++ b/rand_xoshiro/src/xoshiro256plus.rs
@@ -174,6 +174,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -194,6 +195,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
@@ -209,6 +211,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoshiro256plusplus.rs
+++ b/rand_xoshiro/src/xoshiro256plusplus.rs
@@ -174,6 +174,7 @@ mod tests {
     ];
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = Xoshiro256PlusPlus::from_seed(SEED);
@@ -195,6 +196,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_matches_predefined_jumps() {
         let mut a = Xoshiro256PlusPlus::from_seed(SEED);
         a.jump();
@@ -210,6 +212,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoshiro256starstar.rs
+++ b/rand_xoshiro/src/xoshiro256starstar.rs
@@ -173,6 +173,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -193,6 +194,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
@@ -208,6 +210,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoshiro512plus.rs
+++ b/rand_xoshiro/src/xoshiro512plus.rs
@@ -192,6 +192,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -212,6 +213,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
@@ -227,6 +229,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoshiro512plusplus.rs
+++ b/rand_xoshiro/src/xoshiro512plusplus.rs
@@ -191,6 +191,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -211,6 +212,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
@@ -226,6 +228,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {

--- a/rand_xoshiro/src/xoshiro512starstar.rs
+++ b/rand_xoshiro/src/xoshiro512starstar.rs
@@ -191,6 +191,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_small_distances_match_stepping() {
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {
             let mut a = fresh();
@@ -211,6 +212,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_ce_matches_predefined_jumps() {
         let mut a = fresh();
         a.jump();
@@ -226,6 +228,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn jump_n_matches_jump_ce() {
         // jump_n(&[d, 0, …]) == jump_ce(d, 0) for a single-word distance.
         for &d in &[0, 1, 2, 3, 7, 64, 1000, 1_000_000] {


### PR DESCRIPTION
The new `jump_n` feature for `rand_xoshiro` resulted in some tests that are very slow with miri. Skip any tests that run longer than 60 seconds with miri.

I used nextest to identify the slow tests, so I also added the corresponding config.