### PR TITLE
Remove inferrable package.readme attributes

### DIFF
--- a/rand_chacha/Cargo.toml
+++ b/rand_chacha/Cargo.toml
@@ -3,7 +3,6 @@ name = "rand_chacha"
 version = "0.10.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers", "The CryptoCorrosion Contributors"]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/rust-random/rngs"
 documentation = "https://docs.rs/rand_chacha"
 homepage = "https://rust-random.github.io/book"

--- a/rand_hc/Cargo.toml
+++ b/rand_hc/Cargo.toml
@@ -3,7 +3,6 @@ name = "rand_hc"
 version = "0.5.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/rust-random/rngs"
 documentation = "https://docs.rs/rand_hc"
 homepage = "https://rust-random.github.io/book"

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -3,7 +3,6 @@ name = "rand_isaac"
 version = "0.5.1"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/rust-random/rngs"
 documentation = "https://docs.rs/rand_isaac"
 homepage = "https://rust-random.github.io/book"

--- a/rand_jitter/Cargo.toml
+++ b/rand_jitter/Cargo.toml
@@ -3,7 +3,6 @@ name = "rand_jitter"
 version = "0.6.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/rust-random/rngs"
 documentation = "https://docs.rs/rand_jitter"
 description = "Random number generator based on timing jitter"

--- a/rand_pcg/Cargo.toml
+++ b/rand_pcg/Cargo.toml
@@ -3,7 +3,6 @@ name = "rand_pcg"
 version = "0.10.2"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/rust-random/rngs"
 documentation = "https://docs.rs/rand_pcg"
 homepage = "https://rust-random.github.io/book"

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -3,7 +3,6 @@ name = "rand_xorshift"
 version = "0.5.0"
 authors = ["The Rand Project Developers", "The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/rust-random/rngs"
 documentation = "https://docs.rs/rand_xorshift"
 homepage = "https://rust-random.github.io/book"

--- a/rand_xoshiro/Cargo.toml
+++ b/rand_xoshiro/Cargo.toml
@@ -3,7 +3,6 @@ name = "rand_xoshiro"
 version = "0.8.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/rust-random/rngs"
 documentation = "https://docs.rs/rand_xoshiro"
 homepage = "https://rust-random.github.io/book"


### PR DESCRIPTION
rustdoc warns about this now:
```
warning: explicit `package.readme` can be inferred
 --> rand_chacha/Cargo.toml:6:1
  |
6 | readme = "README.md"
  | ^^^^^^^^^^^^^^^^^^^^
  |
  = note: `cargo::manual_readme` is set to `warn` by default
help: consider removing `package.readme`
warning: `rand_chacha` (manifest) generated 1 warning
```